### PR TITLE
Add companion ALTERs for vfs_workspaces columns

### DIFF
--- a/crates/store-pg/migrations/002_vfs.sql
+++ b/crates/store-pg/migrations/002_vfs.sql
@@ -68,6 +68,32 @@ CREATE TABLE IF NOT EXISTS vfs_workspaces (
         CHECK (updated_at_ms >= created_at_ms)
 );
 
+ALTER TABLE vfs_workspaces
+    ADD COLUMN IF NOT EXISTS display_name text;
+
+-- Head stats backfill as 0 for pre-existing rows; the engine rewrites them
+-- from the manifest on the next workspace update. DROP DEFAULT keeps the
+-- upgraded schema identical to a fresh one (inserts must provide values).
+ALTER TABLE vfs_workspaces
+    ADD COLUMN IF NOT EXISTS head_files bigint NOT NULL DEFAULT 0;
+ALTER TABLE vfs_workspaces
+    ALTER COLUMN head_files DROP DEFAULT;
+ALTER TABLE vfs_workspaces
+    ADD COLUMN IF NOT EXISTS head_bytes bigint NOT NULL DEFAULT 0;
+ALTER TABLE vfs_workspaces
+    ALTER COLUMN head_bytes DROP DEFAULT;
+
+ALTER TABLE vfs_workspaces
+    DROP CONSTRAINT IF EXISTS vfs_workspaces_head_files_nonnegative;
+ALTER TABLE vfs_workspaces
+    ADD CONSTRAINT vfs_workspaces_head_files_nonnegative
+        CHECK (head_files >= 0);
+ALTER TABLE vfs_workspaces
+    DROP CONSTRAINT IF EXISTS vfs_workspaces_head_bytes_nonnegative;
+ALTER TABLE vfs_workspaces
+    ADD CONSTRAINT vfs_workspaces_head_bytes_nonnegative
+        CHECK (head_bytes >= 0);
+
 CREATE INDEX IF NOT EXISTS vfs_workspaces_head_digest_idx
     ON vfs_workspaces (universe_id, head_snapshot_digest);
 


### PR DESCRIPTION
Found deploying the ls.bot platform to hz01: `vfs/workspaces/list` fails on any database initialized before 88dfeee with `column "display_name" does not exist`.

88dfeee added `display_name`, `head_files`, and `head_bytes` to the `vfs_workspaces` CREATE TABLE in place, but unlike the other in-place edits (`universes.created_at_ms`, `sessions.display_name`) it has no companion `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` — so existing databases silently keep the old shape while fresh ones get the new one.

- `display_name`: plain nullable add.
- `head_files` / `head_bytes`: `NOT NULL DEFAULT 0` backfill for pre-existing rows, then `DROP DEFAULT` so the upgraded schema matches a fresh one (the engine rewrites the stats from the manifest on the next workspace update).
- The two nonnegative CHECK constraints: drop-if-exists + re-add for idempotency.

Verified against a scratch Postgres 17.10: applied the pre-88dfeee 001+002, then current 001+002 (upgrade succeeds, columns present with correct nullability and no lingering defaults), then current 001+002 again (idempotent, NOTICE-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)