### PR TITLE
Fix release finalization on containerized builder

### DIFF
--- a/scripts/release/create-manifest.mjs
+++ b/scripts/release/create-manifest.mjs
@@ -32,19 +32,24 @@ const archive = (key, needle) => {
 };
 const clientFile = fs.readdirSync("dist/npm").find((entry) => entry.endsWith(".tgz"));
 if (!clientFile) throw new Error("missing TypeScript client tarball");
-const existingBuildImage = fs.existsSync("dist/release-manifest.json")
-  ? JSON.parse(fs.readFileSync("dist/release-manifest.json", "utf8")).buildImage
+const existingManifest = fs.existsSync("dist/release-manifest.json")
+  ? JSON.parse(fs.readFileSync("dist/release-manifest.json", "utf8"))
   : undefined;
-const buildImage = process.env.LIGHTSPEED_RELEASE_BUILD_IMAGE ?? existingBuildImage;
+const buildImage = process.env.LIGHTSPEED_RELEASE_BUILD_IMAGE ?? existingManifest?.buildImage;
 if (!/@sha256:[0-9a-f]{64}$/.test(buildImage ?? "")) {
   throw new Error("LIGHTSPEED_RELEASE_BUILD_IMAGE must identify the actual digest-pinned build image");
+}
+const rustVersion = existingManifest?.rustVersion
+  ?? execFileSync("rustc", ["--version"], { encoding: "utf8" }).trim();
+if (typeof rustVersion !== "string" || rustVersion.length === 0) {
+  throw new Error("release manifest must identify the Rust toolchain used by the build environment");
 }
 
 const manifest = {
   manifestVersion: 1,
   version,
   gitSha,
-  rustVersion: execFileSync("rustc", ["--version"], { encoding: "utf8" }).trim(),
+  rustVersion,
   target: metadata.LIGHTSPEED_RELEASE_TARGET,
   buildImage,
   protocolVersion: metadata.LIGHTSPEED_API_PROTOCOL_VERSION,

--- a/scripts/release/run-build-env.sh
+++ b/scripts/release/run-build-env.sh
@@ -21,4 +21,20 @@ docker run --rm --platform linux/amd64 \
   -v lightspeed-cargo-registry:/usr/local/cargo/registry \
   -v lightspeed-release-target:/workspace/target \
   -v "$(pwd):/workspace" "$build_image" \
-  bash -c 'scripts/release/build-dist.sh && chown -R "$(stat -c %u:%g /workspace)" /workspace/dist'
+  bash -c '
+    cleanup() {
+      status=$?
+      trap - EXIT
+      if [[ -e /workspace/dist ]]; then
+        chown -R "$(stat -c %u:%g /workspace)" /workspace/dist || {
+          cleanup_status=$?
+          if (( status == 0 )); then
+            status=$cleanup_status
+          fi
+        }
+      fi
+      exit "$status"
+    }
+    trap cleanup EXIT
+    scripts/release/build-dist.sh
+  '


### PR DESCRIPTION
## What changed

- preserve the Rust toolchain version recorded inside the digest-pinned build environment during manifest finalization
- restore host ownership of release outputs even when the containerized build fails

## Why

The hz01 snapshot builder intentionally has no host Rust toolchain. Manifest finalization incorrectly queried host rustc, and failed container builds could leave root-owned output directories that blocked the next checkout.

## Validation

- node syntax check
- Bash syntax check
- git diff check
- successful coherent artifact and image build on hz01 before the host-only manifest step