### PR TITLE
Normalize release workspace ownership after container builds

### DIFF
--- a/scripts/release/run-build-env.sh
+++ b/scripts/release/run-build-env.sh
@@ -25,14 +25,14 @@ docker run --rm --platform linux/amd64 \
     cleanup() {
       status=$?
       trap - EXIT
-      if [[ -e /workspace/dist ]]; then
-        chown -R "$(stat -c %u:%g /workspace)" /workspace/dist || {
-          cleanup_status=$?
-          if (( status == 0 )); then
-            status=$cleanup_status
-          fi
-        }
-      fi
+      workspace_owner="$(stat -c %u:%g /workspace)"
+      find /workspace -path /workspace/target -prune -o \
+        -exec chown "$workspace_owner" {} + || {
+        cleanup_status=$?
+        if (( status == 0 )); then
+          status=$cleanup_status
+        fi
+      }
       exit "$status"
     }
     trap cleanup EXIT


### PR DESCRIPTION
## What changed

Normalize ownership across the bind-mounted release checkout whenever the container exits, while pruning the named Cargo target volume.

## Why

The release build also creates npm output and node_modules under interop directories. Restricting cleanup to top-level dist left those paths root-owned and blocked the next persistent-runner checkout.

## Validation

- repaired and verified the live hz01 workspace ownership
- Bash syntax check
- git diff check
- no local build commands run