### PR TITLE
Notify ls.bot of main snapshots

### DIFF
--- a/.github/workflows/snapshot-main.yml
+++ b/.github/workflows/snapshot-main.yml
@@ -203,3 +203,26 @@ jobs:
             release-bundle.tar.gz
           if-no-files-found: error
           retention-days: 14
+      - name: Notify ls.bot of the completed snapshot
+        if: steps.current.outputs.publish == 'true'
+        env:
+          LSBOT_DISPATCH_TOKEN: ${{ secrets.LSBOT_DISPATCH_TOKEN }}
+          BUNDLE_DIGEST: ${{ steps.release_bundle.outputs.digest }}
+          LIGHTSPEED_SHA: ${{ steps.identity.outputs.sha }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$LSBOT_DISPATCH_TOKEN" ]]; then
+            echo '::warning::LSBOT_DISPATCH_TOKEN is not configured; the immutable snapshot was published but ls.bot was not notified.'
+            exit 0
+          fi
+          payload="$(jq -cn \
+            --arg sha "$LIGHTSPEED_SHA" \
+            --arg bundle "ghcr.io/${GITHUB_REPOSITORY}/release-bundle@${BUNDLE_DIGEST}" \
+            '{event_type:"lightspeed-main",client_payload:{gitSha:$sha,releaseBundle:$bundle}}')"
+          curl --fail-with-body --silent --show-error --retry 3 \
+            -X POST \
+            -H 'Accept: application/vnd.github+json' \
+            -H "Authorization: Bearer $LSBOT_DISPATCH_TOKEN" \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            https://api.github.com/repos/smartcomputer-ai/ls.bot/dispatches \
+            --data "$payload"

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -94,9 +94,13 @@ version, full source commit, target, and Rust version through `--version`.
   public snapshot identity. Consumers resolve that tag once and follow only the
   digest-pinned component references in its manifest. A superseded or canceled
   run may leave staging objects but cannot expose a complete snapshot.
-- The ls.bot notification/dispatch step is intentionally not wired yet. For
-  now, a completed `release-bundle:sha-<full-sha>` is the output that ls.bot can
-  consume later by digest.
+- After every completed current-main snapshot, the workflow sends ls.bot a
+  `lightspeed-main` repository dispatch containing the full Git SHA and exact
+  release-bundle digest. Configure `LSBOT_DISPATCH_TOKEN` as a narrowly scoped
+  GitHub App installation token or fine-grained token that may trigger Actions
+  in `smartcomputer-ai/ls.bot`. Until the secret exists, snapshot publication
+  succeeds with an explicit warning and an operator can dispatch the digest
+  manually.
 - A `v<product-version>` annotated tag on `main` triggers
   `.github/workflows/release-tag.yml`. It independently tests and builds the
   exact tagged commit, applies SemVer aliases from the manifest's exact
@@ -106,6 +110,7 @@ version, full source commit, target, and Rust version through `--version`.
   looks up or promotes a prior main snapshot.
 
 The `official-release` GitHub environment protects tagged-release credentials;
-configure `NPM_TOKEN` only there. Snapshot publication uses only the scoped
-GitHub token. Deployment remains outside these workflows until the explicit
-ls.bot notification is added.
+configure `NPM_TOKEN` only there. Snapshot publication uses the scoped GitHub
+token; only the final cross-repository notification uses
+`LSBOT_DISPATCH_TOKEN`. That notification starts ls.bot's own checks and image
+publication, not a production deployment.

--- a/docs/roadmap/p123-build-and-release.md
+++ b/docs/roadmap/p123-build-and-release.md
@@ -29,7 +29,7 @@ Remaining outside this repository:
 
 - provision and harden the hz01 build VM/runner carrying the workflow labels;
 - configure GitHub release environments and npm publication credentials;
-- wire the exact completed snapshot-bundle digest into ls.bot, pin its manifest,
-  and remove the sibling-source build;
+- install the narrowly scoped `LSBOT_DISPATCH_TOKEN` secret so the implemented
+  exact snapshot-bundle dispatch reaches ls.bot;
 - complete the deployment/migration/rollback drill; and
 - retire the hz02 CI guest after the required acceptance runs.


### PR DESCRIPTION
## What changed

After a current-main snapshot is fully published, verified, attested, and uploaded, send ls.bot a `lightspeed-main` repository dispatch containing the exact Git SHA and release-bundle digest.

The step is guarded: until `LSBOT_DISPATCH_TOKEN` is configured, snapshot publication succeeds with an explicit warning. The dispatch starts ls.bot checks and image publication; it does not deploy production.

## Why

ls.bot now consumes immutable Lightspeed snapshots and needs the completed digest rather than a sibling source checkout. The ordinary workflow `GITHUB_TOKEN` cannot trigger the cross-repository workflow.

## Validation

- workflow YAML parsed
- `git diff --check` passed
- no build was run for this workflow-only change