### PR TITLE
Fit Incus network names within Linux interface limit

### DIFF
--- a/crates/environment-provider-incus/src/incus.rs
+++ b/crates/environment-provider-incus/src/incus.rs
@@ -477,8 +477,11 @@ impl IncusClient {
             .request(Method::GET, "/projects?recursion=1", None, None)
             .await?;
         let mut networks = Vec::new();
-        for project in projects.into_iter().filter(Project::is_lightspeed_managed) {
-            let network_name = format!("{}-net", project.name);
+        for project in projects {
+            let Some(binding) = project.binding_context() else {
+                continue;
+            };
+            let network_name = policy::network_name(&binding);
             if !self
                 .exists(&format!("/networks/{network_name}"), Some(&project.name))
                 .await?
@@ -1093,25 +1096,23 @@ struct Project {
 }
 
 impl Project {
-    fn is_lightspeed_managed(&self) -> bool {
+    fn binding_context(&self) -> Option<ProviderBindingContext> {
         if self
             .config
             .get("user.lightspeed.managed")
             .is_none_or(|value| value != "true")
         {
-            return false;
+            return None;
         }
-        let Some(universe_id) = self.config.get("user.lightspeed.universe") else {
-            return false;
+        let binding = ProviderBindingContext {
+            universe_id: self.config.get("user.lightspeed.universe")?.clone(),
+            binding_id: self.config.get("user.lightspeed.binding")?.clone(),
         };
-        let Some(binding_id) = self.config.get("user.lightspeed.binding") else {
-            return false;
-        };
-        self.name
-            == policy::project_name(&ProviderBindingContext {
-                universe_id: universe_id.clone(),
-                binding_id: binding_id.clone(),
-            })
+        (self.name == policy::project_name(&binding)).then_some(binding)
+    }
+
+    fn is_lightspeed_managed(&self) -> bool {
+        self.binding_context().is_some()
     }
 }
 

--- a/crates/environment-provider-incus/src/policy.rs
+++ b/crates/environment-provider-incus/src/policy.rs
@@ -22,7 +22,11 @@ pub fn project_name(binding: &ProviderBindingContext) -> String {
 }
 
 pub fn network_name(binding: &ProviderBindingContext) -> String {
-    format!("{}-net", project_name(binding))
+    let component = stable_component("binding", &[&binding.universe_id, &binding.binding_id]);
+    // A managed bridge's Incus network name also becomes its Linux interface
+    // name, whose hard limit is 15 bytes. Keep 48 bits of the scoped digest
+    // while making the resource kind visible within that limit.
+    format!("ls{}n", &component[..12])
 }
 pub fn profile_name(binding: &ProviderBindingContext) -> String {
     format!("{}-vm", project_name(binding))
@@ -64,5 +68,20 @@ mod tests {
         let a = instance_name("u", "b", "e", "i");
         assert_eq!(a, instance_name("u", "b", "e", "i"));
         assert_ne!(a, instance_name("u2", "b", "e", "i"));
+    }
+
+    #[test]
+    fn binding_network_names_fit_the_linux_interface_limit() {
+        let binding = ProviderBindingContext {
+            universe_id: "0d3d9e5e-2428-4e60-b66e-8d4520f64e5d".to_owned(),
+            binding_id: "hz02-incus".to_owned(),
+        };
+        let other = ProviderBindingContext {
+            universe_id: "61092591-cd39-4504-b845-a817e3d9cb71".to_owned(),
+            binding_id: "hz02-incus".to_owned(),
+        };
+
+        assert_eq!(network_name(&binding).len(), 15);
+        assert_ne!(network_name(&binding), network_name(&other));
     }
 }


### PR DESCRIPTION
Derive the per-binding Incus network from a 48-bit scoped digest in a 15-byte resource name, and make ACL reconciliation derive that same name from the project binding metadata. Adds a focused length and scoping test. This fixes production provisioning failing before VM creation on Incus 6.