### PR TITLE
fix standalone release package staging

### DIFF
--- a/scripts/release/build-dist.sh
+++ b/scripts/release/build-dist.sh
@@ -35,6 +35,14 @@ cp crates/api/contract/api.schema.json crates/api/contract/methods.json \
 npm ci
 npm run build
 
+# The publishable client and Configurator retain standalone lockfiles. Prime
+# npm's cache from those exact locks before their staged installs go offline;
+# the root workspace lock may legitimately resolve different transitive
+# versions and therefore cannot guarantee that every standalone tarball is
+# cached.
+npm --prefix clients/typescript ci --ignore-scripts
+npm --prefix platform/configurator-mcp ci --ignore-scripts
+
 stage_root="$(mktemp -d)"
 trap 'rm -rf "$stage_root"' EXIT
 cp -R clients/typescript "$stage_root/ts-client"

--- a/scripts/release/run-build-env.sh
+++ b/scripts/release/run-build-env.sh
@@ -26,7 +26,8 @@ docker run --rm --platform linux/amd64 \
       status=$?
       trap - EXIT
       workspace_owner="$(stat -c %u:%g /workspace)"
-      find /workspace -path /workspace/target -prune -o \
+      find /workspace \
+        \( -path /workspace/.git -o -path /workspace/target \) -prune -o \
         -exec chown "$workspace_owner" {} + || {
         cleanup_status=$?
         if (( status == 0 )); then


### PR DESCRIPTION
## What changed

- prime npm's cache from the standalone TypeScript client and Configurator lockfiles before offline release staging
- skip `.git` while restoring generated-file ownership after containerized local release builds

## Root cause

The monorepo root lock resolved Vitest 3.2.7, while the publishable client's standalone lock resolved Vitest 3.2.6. Root `npm ci` therefore did not cache the exact tarball required by the later `npm ci --offline` staging step, causing the `main` snapshot to fail with `ENOTCACHED`.

## Impact

Snapshot and tagged release builds can keep their deterministic offline staging while allowing standalone release locks to resolve versions independently from the root workspace lock. Local macOS release builds also exit cleanly after container cleanup.

## Validation

- `bash -n scripts/release/build-dist.sh scripts/release/run-build-env.sh`
- `git diff --check`
- complete Linux/amd64 release build using `release/build-env.Dockerfile` with an ephemeral npm cache: Rust and TypeScript builds, offline client and Configurator staging, platform and Channels runtime staging, archives, SBOM, checksums, smoke checks, and cleanup all passed