### PR TITLE
Package Configurator runtime dependencies

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,4 +2,6 @@
 .env
 target
 **/node_modules
+!dist/configurator-mcp/node_modules
+!dist/configurator-mcp/node_modules/**
 **/.DS_Store

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -231,9 +231,6 @@ jobs:
           docker cp "$container_id:/usr/local/bin/lightspeed-server" image-check/lightspeed-server
           cmp dist/bin/lightspeed-server image-check/lightspeed-server
           docker run --rm "$RUNTIME_IMAGE" --version | grep -F "$EXPECTED_SHA"
-          docker pull "$CONFIGURATOR_IMAGE"
-          docker run --rm --entrypoint node "$CONFIGURATOR_IMAGE" -e \
-            'const fs = require("node:fs"); for (const f of ["/app/dist/bin.js", "/app/agent-client.tgz"]) fs.accessSync(f);'
           scripts/release/smoke-images.sh
       - uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:

--- a/.github/workflows/snapshot-main.yml
+++ b/.github/workflows/snapshot-main.yml
@@ -207,9 +207,6 @@ jobs:
           docker cp "$container_id:/usr/local/bin/lightspeed-server" image-check/lightspeed-server
           cmp dist/bin/lightspeed-server image-check/lightspeed-server
           docker run --rm "$RUNTIME_IMAGE" --version | grep -F "$EXPECTED_SHA"
-          docker pull "$CONFIGURATOR_IMAGE"
-          docker run --rm --entrypoint node "$CONFIGURATOR_IMAGE" -e \
-            'const fs = require("node:fs"); for (const f of ["/app/dist/bin.js", "/app/agent-client.tgz"]) fs.accessSync(f);'
           scripts/release/smoke-images.sh
       - name: Confirm this is still the current main commit
         id: current

--- a/scripts/release/build-images.sh
+++ b/scripts/release/build-images.sh
@@ -30,8 +30,8 @@ trap 'docker rm -f "$container_id" >/dev/null 2>&1 || true; rm -rf "$tmp_dir"' E
 docker cp "$container_id:/usr/local/bin/lightspeed-server" "$tmp_dir/lightspeed-server"
 cmp dist/bin/lightspeed-server "$tmp_dir/lightspeed-server"
 docker run --rm "${tag}-runtime" --version
-docker run --rm --entrypoint node "${tag}-configurator-mcp" -e \
-  'for (const file of ["/app/dist/bin.js", "/app/agent-client.tgz"]) require("node:fs").accessSync(file)'
+docker run --rm --entrypoint node "${tag}-configurator-mcp" \
+  --input-type=module -e 'await import("/app/dist/index.js")'
 docker run --rm --entrypoint node "${tag}-platform" -e \
   'for (const file of ["/app/platform/server/src/main.ts", "/app/platform/web/dist/index.html"]) require("node:fs").accessSync(file)'
 for image in runtime platform channels; do

--- a/scripts/release/smoke-images.sh
+++ b/scripts/release/smoke-images.sh
@@ -3,10 +3,12 @@ set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/../.."
 
 platform_image="${PLATFORM_IMAGE:?PLATFORM_IMAGE is required}"
+configurator_image="${CONFIGURATOR_IMAGE:?CONFIGURATOR_IMAGE is required}"
 channels_image="${LIGHTSPEED_CHANNELS_IMAGE:?LIGHTSPEED_CHANNELS_IMAGE is required}"
 expected_sha="${EXPECTED_SHA:?EXPECTED_SHA is required}"
 
 docker pull "$platform_image"
+docker pull "$configurator_image"
 docker pull "$channels_image"
 
 test "$(docker image inspect "$platform_image" \
@@ -39,6 +41,11 @@ if [[ "$ready" != true ]]; then
 fi
 curl --fail --silent http://127.0.0.1:18300/app \
   | grep -F '<div id="root"></div>' >/dev/null
+
+test "$(docker image inspect "$configurator_image" \
+  --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}')" = "$expected_sha"
+docker run --rm --entrypoint node "$configurator_image" \
+  --input-type=module -e 'await import("/app/dist/index.js")'
 
 test "$(docker image inspect "$channels_image" \
   --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}')" = "$expected_sha"


### PR DESCRIPTION
## Summary

- include the staged Configurator production dependency tree in Docker build contexts
- make local, snapshot, and tagged-release smoke checks import the packaged application graph
- verify the Configurator image revision alongside other published images

## Root cause

Release staging ran `npm ci --omit=dev`, but `.dockerignore` excluded every `node_modules` directory. The image therefore contained `agent-client.tgz` without installed runtime packages, and the existing smoke check only asserted that the tarball and entrypoint files existed.

## Impact

Configurator images now contain their runtime dependencies. A recurrence fails release smoke verification before an immutable bundle is published.

## Validation

- built `release/configurator-mcp.Dockerfile` locally from the staged release tree
- imported `/app/dist/index.js` from the resulting image
- verified packaged `@lightspeed/agent-client` and `express` manifests
- `npm --prefix platform/configurator-mcp test` (16 tests)
- `bash -n scripts/release/build-images.sh scripts/release/smoke-images.sh`
- `git diff --check`