### PR TITLE
Fix standalone Incus provider networking

### DIFF
--- a/crates/environment-provider-incus/src/incus.rs
+++ b/crates/environment-provider-incus/src/incus.rs
@@ -482,8 +482,9 @@ impl IncusClient {
                 continue;
             };
             let network_name = policy::network_name(&binding);
+            let network_project = network_resource_project(self.config.incus.mode, &project.name);
             if !self
-                .exists(&format!("/networks/{network_name}"), Some(&project.name))
+                .exists(&format!("/networks/{network_name}"), network_project)
                 .await?
             {
                 continue;
@@ -492,7 +493,7 @@ impl IncusClient {
                 .request(
                     Method::GET,
                     &format!("/networks/{network_name}"),
-                    Some(&project.name),
+                    network_project,
                     None,
                 )
                 .await?;
@@ -522,6 +523,7 @@ impl IncusClient {
         }
 
         for (project, own_cidr) in &networks {
+            let network_project = network_resource_project(self.config.incus.mode, project);
             let siblings = networks
                 .iter()
                 .filter(|(_, cidr)| cidr != own_cidr)
@@ -562,7 +564,7 @@ impl IncusClient {
             self.request_unit(
                 Method::PUT,
                 &format!("/network-acls/{project}-acl"),
-                Some(project),
+                network_project,
                 Some(json!({
                     "description":"Lightspeed binding baseline",
                     "ingress":ingress,
@@ -614,8 +616,10 @@ impl IncusBackend for IncusClient {
     async fn reconcile_binding(&self, binding: &ProviderBindingContext) -> anyhow::Result<()> {
         let _reconcile_guard = self.reconcile_lock.lock().await;
         let project = policy::project_name(binding);
-        self.ensure_resource(&format!("/projects/{project}"), "/projects", None, json!({"name":project,"description":"Lightspeed managed binding","config":{"features.images":"false","features.networks":"true","features.profiles":"true","restricted":"true","restricted.devices.nic":"managed","restricted.devices.disk":"managed","restricted.networks.access":policy::network_name(binding),"user.lightspeed.managed":"true","user.lightspeed.universe":binding.universe_id,"user.lightspeed.binding":binding.binding_id}})).await?;
-        self.ensure_resource(&format!("/network-acls/{}", policy::acl_name(binding)), "/network-acls", Some(&project), json!({"name":policy::acl_name(binding),"description":"Lightspeed binding baseline","ingress":[],"egress":[],"config":{}})).await?;
+        let isolated_project_networks = self.config.incus.mode == IncusMode::Cluster;
+        let network_project = network_resource_project(self.config.incus.mode, &project);
+        self.ensure_resource(&format!("/projects/{project}"), "/projects", None, json!({"name":project,"description":"Lightspeed managed binding","config":{"features.images":"false","features.networks":isolated_project_networks.to_string(),"features.profiles":"true","restricted":"true","restricted.devices.nic":"managed","restricted.devices.disk":"managed","restricted.networks.access":policy::network_name(binding),"user.lightspeed.managed":"true","user.lightspeed.universe":binding.universe_id,"user.lightspeed.binding":binding.binding_id}})).await?;
+        self.ensure_resource(&format!("/network-acls/{}", policy::acl_name(binding)), "/network-acls", network_project, json!({"name":policy::acl_name(binding),"description":"Lightspeed binding baseline","ingress":[],"egress":[],"config":{}})).await?;
         let network = match self.config.incus.mode {
             IncusMode::Single => {
                 json!({"name":policy::network_name(binding),"type":"bridge","config":{"ipv4.address":"auto","ipv4.nat":"true","ipv6.address":"none","security.acls":policy::acl_name(binding),"security.acls.default.ingress.action":"allow","security.acls.default.egress.action":"allow"}})
@@ -627,7 +631,7 @@ impl IncusBackend for IncusClient {
         self.ensure_resource(
             &format!("/networks/{}", policy::network_name(binding)),
             "/networks",
-            Some(&project),
+            network_project,
             network,
         )
         .await?;
@@ -1161,6 +1165,8 @@ struct InstanceState {
 #[derive(Default, Deserialize)]
 struct NetworkState {
     #[serde(default)]
+    host_name: String,
+    #[serde(default)]
     addresses: Vec<Address>,
 }
 #[derive(Deserialize)]
@@ -1197,6 +1203,27 @@ fn ipv4_cidrs_overlap(left: &str, right: &str) -> bool {
 
 fn pending_operation(operation: Option<String>) -> Option<String> {
     operation.filter(|operation| !operation.is_empty())
+}
+
+fn managed_ipv4_address(state: &InstanceState) -> Option<String> {
+    state
+        .network
+        .values()
+        // Incus reports a host-side interface for managed instance NICs.
+        // Guest-created networks such as Docker's bridge have no host_name.
+        .filter(|network| !network.host_name.is_empty())
+        .flat_map(|network| &network.addresses)
+        .find(|address| address.family == "inet" && address.scope == "global")
+        .map(|address| address.address.clone())
+}
+
+/// OVN networks are project-local, while standalone bridge networks are
+/// global Incus resources that restricted projects are allowed to reference.
+fn network_resource_project(mode: IncusMode, project: &str) -> Option<&str> {
+    match mode {
+        IncusMode::Single => None,
+        IncusMode::Cluster => Some(project),
+    }
 }
 
 fn parse_source_target(value: &str) -> anyhow::Result<(&str, &str)> {
@@ -1291,12 +1318,7 @@ fn owned_from_instance(instance: Instance, state: InstanceState) -> anyhow::Resu
     {
         anyhow::bail!("managed instance name does not match immutable ownership metadata")
     }
-    let ipv4_address = state
-        .network
-        .values()
-        .flat_map(|network| &network.addresses)
-        .find(|address| address.family == "inet" && address.scope == "global")
-        .map(|address| address.address.clone());
+    let ipv4_address = managed_ipv4_address(&state);
     Ok(OwnedTarget {
         target_id: ProviderTargetId::new(instance.name.clone()),
         name: instance.name,
@@ -1385,5 +1407,48 @@ mod tests {
             ("staging", "manual-vm")
         );
         assert!(parse_source_target("too/many/parts").is_err());
+    }
+
+    #[test]
+    fn standalone_network_resources_are_global_but_cluster_networks_are_project_local() {
+        assert_eq!(
+            network_resource_project(IncusMode::Single, "binding-a"),
+            None
+        );
+        assert_eq!(
+            network_resource_project(IncusMode::Cluster, "binding-a"),
+            Some("binding-a")
+        );
+    }
+
+    #[test]
+    fn managed_ipv4_ignores_guest_created_bridges() {
+        let state = InstanceState {
+            network: BTreeMap::from([
+                (
+                    "docker0".to_owned(),
+                    NetworkState {
+                        host_name: String::new(),
+                        addresses: vec![Address {
+                            family: "inet".to_owned(),
+                            scope: "global".to_owned(),
+                            address: "172.17.0.1".to_owned(),
+                        }],
+                    },
+                ),
+                (
+                    "enp5s0".to_owned(),
+                    NetworkState {
+                        host_name: "tap123".to_owned(),
+                        addresses: vec![Address {
+                            family: "inet".to_owned(),
+                            scope: "global".to_owned(),
+                            address: "10.42.0.2".to_owned(),
+                        }],
+                    },
+                ),
+            ]),
+        };
+        assert_eq!(managed_ipv4_address(&state).as_deref(), Some("10.42.0.2"));
     }
 }

--- a/crates/environment-provider-incus/src/server.rs
+++ b/crates/environment-provider-incus/src/server.rs
@@ -527,15 +527,23 @@ fn summary(target: OwnedTarget) -> ProviderTargetSummary {
     if let Some(location) = target.location {
         metadata.insert("incusMember".to_owned(), location);
     }
+    let mut capabilities = EnvironmentCapabilities::filesystem(true, true)
+        .with_filesystem_search()
+        .with_process()
+        .with_jobs();
+    // Keep the controller-plane summary aligned with the envd handshake. The
+    // runtime consumes this summary before opening the data-plane connection.
+    capabilities.network = true;
+    capabilities.filesystem_glob = true;
+    capabilities.filesystem_ranged_read = true;
+    capabilities.process_output_notifications = false;
+    capabilities.process_pty = true;
     ProviderTargetSummary {
         target_id: target.target_id,
         display_name: Some(target.environment_id),
         status: target.status,
         scope: EnvironmentScope::Default,
-        capabilities: EnvironmentCapabilities::filesystem(true, true)
-            .with_filesystem_search()
-            .with_process()
-            .with_jobs(),
+        capabilities,
         default_cwd: None,
         metadata,
     }
@@ -622,5 +630,10 @@ mod tests {
             summary.metadata.get("incusMember").map(String::as_str),
             Some("member-a")
         );
+        assert!(summary.capabilities.network);
+        assert!(summary.capabilities.filesystem_glob);
+        assert!(summary.capabilities.filesystem_ranged_read);
+        assert!(summary.capabilities.process_pty);
+        assert!(!summary.capabilities.process_output_notifications);
     }
 }


### PR DESCRIPTION
## What changed

- create standalone bridge networks and their ACLs as global Incus resources while keeping binding projects restricted to their assigned bridge
- keep OVN networks project-local in cluster mode
- select the Incus-managed guest NIC instead of guest-created bridges such as Docker's `docker0`
- align controller-plane target capabilities with the envd handshake
- add regression coverage for standalone resource scope, managed-NIC selection, and capability reporting

## Root cause

Incus does not allow managed bridge networks inside non-default projects, so the single-node provider failed its first `createTarget` call. After correcting that scope, readiness still selected Docker's `172.17.0.1` instead of the managed NIC address, leaving a healthy envd target stuck in `starting`.

## Impact

The standalone hz02 provider can now provision isolated VMs, discover envd readiness, relay filesystem/process/job traffic, enforce denied egress, manage ingress, recover across provider and VM restarts, and close targets idempotently.

## Validation

- `cargo fmt --check`
- `cargo test -p environment-provider-incus -p environment-daemon` (44 passed)
- `cargo clippy -p environment-provider-incus --all-targets -- -D warnings`
- live Mac provider against hz02 through a tunneled Incus API: create, repeated create, conflict fencing, inventory, force close
- amd64 Linux candidate on hz02 alternate ports: create/adopt, readiness, envd relay, filesystem, Docker/process/PTY, durable dependent jobs, internet egress with tailnet denial, ingress fencing/routing/revocation, provider restart, VM restart persistence, stale-incarnation denial, and idempotent close
- all disposable Incus resources and candidate files were removed after the run