### PR TITLE
Fix Incus start state race

### DIFF
--- a/crates/environment-provider-incus/src/incus.rs
+++ b/crates/environment-provider-incus/src/incus.rs
@@ -825,9 +825,11 @@ impl IncusBackend for IncusClient {
                 return Err(error);
             }
         }
-        self.instance(&project, &name)
+        let target = self
+            .instance(&project, &name)
             .await?
-            .ok_or_else(|| anyhow::anyhow!("created Incus instance disappeared"))
+            .ok_or_else(|| anyhow::anyhow!("created Incus instance disappeared"))?;
+        Ok(target_after_accepted_start(target))
     }
 
     async fn adopt_vm(
@@ -1276,10 +1278,26 @@ async fn ensure_instance_started(
             return Err(error);
         }
     }
-    client
+    let target = client
         .instance(project, name)
         .await?
-        .ok_or_else(|| anyhow::anyhow!("adopted Incus target disappeared while starting"))
+        .ok_or_else(|| anyhow::anyhow!("Incus target disappeared while starting"))?;
+    Ok(target_after_accepted_start(target))
+}
+
+/// Incus can briefly return the pre-operation `Stopped` state immediately
+/// after its asynchronous start operation succeeds. Keep the provisioning
+/// lifecycle pending until a later observation sees the actual running state.
+fn target_after_accepted_start(mut target: OwnedTarget) -> OwnedTarget {
+    target.status = status_after_accepted_start(target.status);
+    target
+}
+
+fn status_after_accepted_start(status: ProviderTargetStatus) -> ProviderTargetStatus {
+    match status {
+        ProviderTargetStatus::Stopped => ProviderTargetStatus::Starting,
+        status => status,
+    }
 }
 
 fn verify_adopted_target(target: &OwnedTarget, params: &AdoptTargetParams) -> anyhow::Result<()> {
@@ -1450,5 +1468,17 @@ mod tests {
             ]),
         };
         assert_eq!(managed_ipv4_address(&state).as_deref(), Some("10.42.0.2"));
+    }
+
+    #[test]
+    fn accepted_start_does_not_report_a_stale_stopped_state() {
+        assert_eq!(
+            status_after_accepted_start(ProviderTargetStatus::Stopped),
+            ProviderTargetStatus::Starting
+        );
+        assert_eq!(
+            status_after_accepted_start(ProviderTargetStatus::Ready),
+            ProviderTargetStatus::Ready
+        );
     }
 }

--- a/crates/environment-provider-incus/src/incus.rs
+++ b/crates/environment-provider-incus/src/incus.rs
@@ -977,15 +977,28 @@ impl IncusBackend for IncusClient {
         force: bool,
     ) -> anyhow::Result<()> {
         let project = policy::project_name(binding);
-        if force {
-            let _ = self
+        if target.status != ProviderTargetStatus::Stopped {
+            let stop_result = self
                 .request_unit(
                     Method::PUT,
                     &format!("/instances/{}/state", target.name),
                     Some(&project),
-                    Some(json!({"action":"stop","timeout":0,"force":true})),
+                    Some(json!({
+                        "action":"stop",
+                        "timeout": if force { 0 } else { 30 },
+                        "force": force
+                    })),
                 )
                 .await;
+            if let Err(error) = stop_result {
+                let observed = self.instance(&project, &target.name).await?;
+                if observed
+                    .as_ref()
+                    .is_some_and(|target| target.status != ProviderTargetStatus::Stopped)
+                {
+                    return Err(error);
+                }
+            }
         }
         if let Err(error) = self
             .request_unit(


### PR DESCRIPTION
Fixes a production-discovered lifecycle race where Incus can briefly return `Stopped` immediately after accepting an asynchronous VM start. The provider now keeps the target in `Starting` until a later observation reports the real state, preventing Lightspeed from prematurely finalizing a newly created environment as offline.

Tests:
- `cargo fmt --check`
- `cargo test -p environment-provider-incus`
- `cargo clippy -p environment-provider-incus --all-targets -- -D warnings`
- production acceptance will be repeated against hz01/hz02 with the patched candidate