### PR TITLE
Fix Bots release packaging and database access

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -263,7 +263,8 @@ upstream Lightspeed gateway.
 
 The Bots workers (workflow and activity roles of `platform/bots`) share the
 Platform database and reach the core runtime through the public JSON-RPC
-endpoint.
+endpoint. Release deployments run them as a separate process from the same
+image payload as Channels.
 
 | Variable | Requirement/default | Purpose |
 | --- | --- | --- |

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build": "npm run build --workspace @lightspeed/agent-client && npm run build --workspace @lightspeed/configurator-mcp && npm run build --workspace @lightspeed/platform-web",
     "build:web": "npm run build --workspace @lightspeed/platform-web",
     "check": "npm run check:dev && npm run check:identity && npm run check:generated && npm run typecheck && npm run test && npm run build",
-    "check:ci": "npm run check && npm run test:migrations && npm run test:integration:channels",
+    "check:ci": "npm run check && npm run test:migrations && npm run test:integration:channels && npm run test:integration:bots",
     "check:dev": "bash -n dev.sh scripts/dev/env.sh scripts/dev/lib/common.sh scripts/dev/infra/*.sh && node --check scripts/dev/stack.mjs && ./dev.sh --help >/dev/null && LIGHTSPEED_CHANNELS_CONNECTORS= node scripts/dev/stack.mjs --plan infra >/dev/null && LIGHTSPEED_CHANNELS_CONNECTORS= node scripts/dev/stack.mjs --plan runtime >/dev/null && LIGHTSPEED_CHANNELS_CONNECTORS= node scripts/dev/stack.mjs --plan platform >/dev/null && LIGHTSPEED_CHANNELS_CONNECTORS= node scripts/dev/stack.mjs --plan full >/dev/null",
     "check:identity": "node platform/scripts/check-product-identity.mjs",
     "check:generated": "npm run check:generated --workspace @lightspeed/agent-client && npm run check:generated --workspace @lightspeed/configurator-mcp && node platform/scripts/generate-config-reference.mjs && git diff --exit-code -- platform/web/src/lib/profile-config-reference.ts",

--- a/platform/bots/test/bots.integration.test.ts
+++ b/platform/bots/test/bots.integration.test.ts
@@ -39,6 +39,10 @@ const botId = "0b54d227-08a2-45a8-9b3f-6a4c21d1a222";
 const botName = "triage";
 const eventRef = `sha256:${"a".repeat(64)}`;
 const resolveRef = `sha256:${"b".repeat(64)}`;
+const defaultUsageActivities = {
+  readBotRunUsage: async () => null,
+  countBotDescendantSessions: async () => ({ count: 0 }),
+};
 
 describe.runIf(runIntegration)("bot controller workflow", () => {
   let env: TestWorkflowEnvironment;
@@ -66,6 +70,7 @@ describe.runIf(runIntegration)("bot controller workflow", () => {
       namespace: env.namespace ?? "default",
       taskQueue: BOTS_ACTIVITY_TASK_QUEUE,
       activities: {
+        ...defaultUsageActivities,
         ensureBotSession: async () => {
           calls.push("ensureSession");
           return { profileRevision: 4 };
@@ -194,6 +199,7 @@ describe.runIf(runIntegration)("bot controller workflow", () => {
       namespace: env.namespace ?? "default",
       taskQueue: BOTS_ACTIVITY_TASK_QUEUE,
       activities: {
+        ...defaultUsageActivities,
         ensureBotSession: async () => ({ profileRevision: 1 }),
         readBotSessionStatus: async () => ({ status: "idle" }),
         startBotRun: async () => {
@@ -273,6 +279,7 @@ describe.runIf(runIntegration)("bot controller workflow", () => {
       namespace: env.namespace ?? "default",
       taskQueue: BOTS_ACTIVITY_TASK_QUEUE,
       activities: {
+        ...defaultUsageActivities,
         ensureBotSession: async () => ({ profileRevision: 1 }),
         readBotSessionStatus: async () => ({ status: "idle" }),
         startBotRun: async () => {
@@ -360,6 +367,7 @@ describe.runIf(runIntegration)("bot controller workflow", () => {
       namespace: env.namespace ?? "default",
       taskQueue: BOTS_ACTIVITY_TASK_QUEUE,
       activities: {
+        ...defaultUsageActivities,
         ensureBotSession: async () => {
           ensured += 1;
           return { profileRevision: ensured };
@@ -443,6 +451,7 @@ describe.runIf(runIntegration)("bot controller workflow", () => {
       namespace: env.namespace ?? "default",
       taskQueue: BOTS_ACTIVITY_TASK_QUEUE,
       activities: {
+        ...defaultUsageActivities,
         ensureBotSession: async ({ sessionId }: { sessionId: string }) => {
           ensured.push(sessionId);
           return { profileRevision: 1 };
@@ -573,6 +582,7 @@ describe.runIf(runIntegration)("bot controller workflow", () => {
       namespace: env.namespace ?? "default",
       taskQueue: BOTS_ACTIVITY_TASK_QUEUE,
       activities: {
+        ...defaultUsageActivities,
         ensureBotSession: async () => ({ profileRevision: 1 }),
         readBotSessionStatus: async () => ({ status: "idle" }),
         startBotRun: async ({
@@ -691,6 +701,7 @@ describe.runIf(runIntegration)("bot controller workflow", () => {
       namespace: env.namespace ?? "default",
       taskQueue: BOTS_ACTIVITY_TASK_QUEUE,
       activities: {
+        ...defaultUsageActivities,
         ensureBotSession: async () => ({ profileRevision: 1 }),
         readBotSessionStatus: async () => ({ status: "idle" }),
         startBotRun: async ({ deliveryId }: { deliveryId: string }) => {
@@ -785,6 +796,7 @@ describe.runIf(runIntegration)("bot controller workflow", () => {
       namespace: env.namespace ?? "default",
       taskQueue: BOTS_ACTIVITY_TASK_QUEUE,
       activities: {
+        ...defaultUsageActivities,
         ensureBotSession: async () => ({ profileRevision: 1 }),
         readBotSessionStatus: async () => ({ status: "active" }),
         startBotRun: async () => {
@@ -873,6 +885,7 @@ describe.runIf(runIntegration)("bot controller workflow", () => {
       namespace: env.namespace ?? "default",
       taskQueue: BOTS_ACTIVITY_TASK_QUEUE,
       activities: {
+        ...defaultUsageActivities,
         ensureBotSession: async () => ({ profileRevision: 1 }),
         readBotSessionStatus: async () => ({ status: hostActive ? "running" : "idle" }),
         startBotRun: async () => {
@@ -979,6 +992,7 @@ describe.runIf(runIntegration)("bot controller workflow", () => {
       namespace: env.namespace ?? "default",
       taskQueue: BOTS_ACTIVITY_TASK_QUEUE,
       activities: {
+        ...defaultUsageActivities,
         ensureBotSession: async ({ sessionId }: { sessionId: string }) => {
           ensured.push(sessionId);
           return { profileRevision: 1 };
@@ -1083,6 +1097,7 @@ describe.runIf(runIntegration)("bot controller workflow", () => {
       namespace: env.namespace ?? "default",
       taskQueue: BOTS_ACTIVITY_TASK_QUEUE,
       activities: {
+        ...defaultUsageActivities,
         ensureBotSession: async ({ sessionId }: { sessionId: string }) => {
           ensured.push(sessionId);
           if (sessionId === keyed) {
@@ -1190,6 +1205,7 @@ describe.runIf(runIntegration)("bot controller workflow", () => {
       namespace: env.namespace ?? "default",
       taskQueue: BOTS_ACTIVITY_TASK_QUEUE,
       activities: {
+        ...defaultUsageActivities,
         ensureBotSession: async () => ({ profileRevision: 1 }),
         readBotSessionStatus: async () => ({ status: "idle" }),
         readWorkflowToolInvocations: async ({ afterSeq }: { afterSeq: number }) => ({
@@ -1316,6 +1332,7 @@ describe.runIf(runIntegration)("bot controller workflow", () => {
       namespace: env.namespace ?? "default",
       taskQueue: BOTS_ACTIVITY_TASK_QUEUE,
       activities: {
+        ...defaultUsageActivities,
         ensureBotSession: async ({ sessionId }: { sessionId: string }) => {
           ensured.push(sessionId);
           if (sessionId === botSessionId(rotateBotName)) {
@@ -1388,6 +1405,7 @@ describe.runIf(runIntegration)("bot controller workflow", () => {
       namespace: env.namespace ?? "default",
       taskQueue: BOTS_ACTIVITY_TASK_QUEUE,
       activities: {
+        ...defaultUsageActivities,
         ensureBotSession: async ({ sessionId }: { sessionId: string }) => {
           ensured.push(sessionId);
           return { profileRevision: 1 };
@@ -1463,6 +1481,7 @@ describe.runIf(runIntegration)("bot controller workflow", () => {
       namespace: env.namespace ?? "default",
       taskQueue: BOTS_ACTIVITY_TASK_QUEUE,
       activities: {
+        ...defaultUsageActivities,
         admitScheduleEvent: async (input: unknown) => {
           admissions.push(input);
           return { admitted: true, eventId: "schedule:test", duplicate: false };
@@ -1563,6 +1582,7 @@ describe.runIf(runIntegration)("bot controller workflow", () => {
       namespace: env.namespace ?? "default",
       taskQueue: BOTS_ACTIVITY_TASK_QUEUE,
       activities: {
+        ...defaultUsageActivities,
         ensureBotSession: async () => ({ profileRevision: 1 }),
         readBotSessionStatus: async () => ({ status: "idle" }),
         readBotRunUsage: async () => null,
@@ -1699,6 +1719,7 @@ describe.runIf(runIntegration)("bot controller workflow", () => {
       namespace: env.namespace ?? "default",
       taskQueue: BOTS_ACTIVITY_TASK_QUEUE,
       activities: {
+        ...defaultUsageActivities,
         ensureBotSession: async (input: { sessionId: string; toolsRef?: string | null }) => {
           ensured.push({ sessionId: input.sessionId, toolsRef: input.toolsRef });
           return {

--- a/platform/db/migrations/0002_bots.sql
+++ b/platform/db/migrations/0002_bots.sql
@@ -87,4 +87,15 @@ CREATE UNIQUE INDEX "bot_events_bot_event_idx" ON "bot_events" USING btree ("bot
 CREATE UNIQUE INDEX "bot_events_bot_seq_idx" ON "bot_events" USING btree ("bot_id","seq");--> statement-breakpoint
 CREATE INDEX "bot_events_bot_received_idx" ON "bot_events" USING btree ("bot_id","created_at");--> statement-breakpoint
 CREATE INDEX "channel_pairings_account_chat_idx" ON "channel_pairings" USING btree ("channel_account_id","chat_id");--> statement-breakpoint
-CREATE INDEX "channel_pairings_trigger_idx" ON "channel_pairings" USING btree ("trigger_id");
+CREATE INDEX "channel_pairings_trigger_idx" ON "channel_pairings" USING btree ("trigger_id");--> statement-breakpoint
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'lightspeed_channels') THEN
+    GRANT SELECT ON "member", "universes", "channel_accounts", "channel_identities"
+      TO lightspeed_channels;
+    GRANT SELECT, INSERT, UPDATE, DELETE
+      ON "bots", "bot_triggers", "bot_events", "channel_pairings"
+      TO lightspeed_channels;
+  END IF;
+END
+$$;

--- a/platform/db/scripts/check-migrations.ts
+++ b/platform/db/scripts/check-migrations.ts
@@ -33,10 +33,12 @@ const upgradeName = checkedIdentifier(`lightspeed_platform_upgrade_${suffix}`);
 const admin = new pg.Client({ connectionString: baseUrl });
 const previousMigrations = await mkdtemp(path.join(tmpdir(), "lightspeed-platform-migrations-"));
 let adminConnected = false;
+let workerRoleCreated = false;
 
 try {
   await admin.connect();
   adminConnected = true;
+  workerRoleCreated = await ensureWorkerRole(admin);
   await createDatabase(admin, emptyName);
   await createDatabase(admin, upgradeName);
 
@@ -60,6 +62,7 @@ try {
   if (adminConnected) {
     await dropDatabase(admin, emptyName);
     await dropDatabase(admin, upgradeName);
+    if (workerRoleCreated) await admin.query("DROP ROLE lightspeed_channels");
   }
   await admin.end().catch(() => undefined);
   await rm(previousMigrations, { recursive: true, force: true });
@@ -82,6 +85,7 @@ async function checkEmptyInstall(connectionString: string): Promise<void> {
     await requireColumn(handle.pool, "bot_events", "outcome");
     await requireColumn(handle.pool, "bot_triggers", "disabled_reason");
     await requireNoTable(handle.pool, "bot_activity");
+    await requireWorkerGrants(handle.pool);
   } finally {
     await handle.pool.end();
   }
@@ -127,9 +131,42 @@ async function checkUpgrade(
     // Event outcomes replace the retired activity feed.
     await requireColumn(handle.pool, "bot_events", "outcome");
     await requireNoTable(handle.pool, "bot_activity");
+    await requireWorkerGrants(handle.pool);
     await requireLedgerLength(handle.pool, journal.entries.length);
   } finally {
     await handle.pool.end();
+  }
+}
+
+async function ensureWorkerRole(client: pg.Client): Promise<boolean> {
+  const result = await client.query<{ present: boolean }>(
+    "select exists (select 1 from pg_roles where rolname = 'lightspeed_channels') as present",
+  );
+  if (result.rows[0]?.present === true) return false;
+  await client.query("CREATE ROLE lightspeed_channels");
+  return true;
+}
+
+async function requireWorkerGrants(pool: pg.Pool): Promise<void> {
+  const readTables = ["member", "universes", "channel_accounts", "channel_identities"];
+  const managedTables = ["bots", "bot_triggers", "bot_events", "channel_pairings"];
+  for (const table of readTables) {
+    await requireTablePrivilege(pool, table, "SELECT");
+  }
+  for (const table of managedTables) {
+    for (const privilege of ["SELECT", "INSERT", "UPDATE", "DELETE"]) {
+      await requireTablePrivilege(pool, table, privilege);
+    }
+  }
+}
+
+async function requireTablePrivilege(pool: pg.Pool, table: string, privilege: string): Promise<void> {
+  const result = await pool.query<{ present: boolean }>(
+    "select has_table_privilege('lightspeed_channels', $1, $2) as present",
+    [`public.${table}`, privilege],
+  );
+  if (result.rows[0]?.present !== true) {
+    throw new Error(`lightspeed_channels lacks ${privilege} on public.${table}`);
   }
 }
 

--- a/scripts/release/smoke-images.sh
+++ b/scripts/release/smoke-images.sh
@@ -52,6 +52,10 @@ test "$(docker image inspect "$channels_image" \
 test "$(docker image inspect "$channels_image" --format '{{json .Config.Cmd}}')" = '["all"]'
 docker run --rm --entrypoint node "$channels_image" -e \
   'require("node:fs").accessSync("/app/node_modules/baileys/package.json")'
+docker run --rm --entrypoint node "$channels_image" --import tsx --input-type=module -e \
+  'await import("@lightspeed/bots/webhooks")'
+docker run --rm --entrypoint node "$channels_image" -e \
+  'require("node:fs").accessSync("/app/platform/bots/src/runtime/main.ts")'
 
 for role in workflows activities telegram whatsapp all; do
   expected="$role"

--- a/scripts/release/smoke.sh
+++ b/scripts/release/smoke.sh
@@ -26,8 +26,10 @@ for runtime in platform channels; do
   tar -tzf "dist/runtime/$runtime.tar.gz" ./package.json >/dev/null
 done
 tar -tzf dist/runtime/platform.tar.gz ./platform/server/src/main.ts >/dev/null
+tar -tzf dist/runtime/platform.tar.gz ./platform/bots/src/webhooks.ts >/dev/null
 tar -tzf dist/runtime/platform.tar.gz ./platform/web/dist/index.html >/dev/null
 tar -tzf dist/runtime/channels.tar.gz ./platform/channels/src/runtime/main.ts >/dev/null
+tar -tzf dist/runtime/channels.tar.gz ./platform/bots/src/runtime/main.ts >/dev/null
 channels_files="$(mktemp)"
 trap 'rm -f "$channels_files"' EXIT
 tar -tzf dist/runtime/channels.tar.gz > "$channels_files"

--- a/scripts/release/stage-runtimes.sh
+++ b/scripts/release/stage-runtimes.sh
@@ -19,6 +19,7 @@ copy_workspace_manifests() {
   cp package.json package-lock.json tsconfig.json "$root/"
   for workspace in \
     clients/typescript \
+    platform/bots \
     platform/channels \
     platform/cli \
     platform/configurator-mcp \
@@ -61,6 +62,7 @@ stage_runtime() {
 
 stage_runtime platform @lightspeed/platform-server \
   clients/typescript/dist \
+  platform/bots/src \
   platform/server/src \
   platform/db/src \
   platform/db/migrations \
@@ -68,6 +70,7 @@ stage_runtime platform @lightspeed/platform-server \
   platform/web/dist
 stage_runtime channels @lightspeed/channels \
   clients/typescript/dist \
+  platform/bots/src \
   platform/channels/src \
   platform/db/src \
   platform/db/migrations


### PR DESCRIPTION
## Summary
- stage the Bots workspace and sources into Platform and Channels runtime artifacts
- grant and verify the shared worker role privileges required by Bots
- exercise Bots integration tests in CI and release smoke checks

## Validation
- npm run check
- npm run test:migrations
- npm run test:integration:channels
- npm run test:integration:bots
- staged runtime install/import smoke checks