### PR TITLE
Fix standalone client release lock

### DIFF
--- a/clients/typescript/package-lock.json
+++ b/clients/typescript/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "@lightspeed/agent-client",
       "version": "0.0.0",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
       "devDependencies": {
         "@types/node": "^24.0.0",
         "json-schema-to-typescript": "^15.0.4",
@@ -490,6 +493,18 @@
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.61.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build": "npm run build --workspace @lightspeed/agent-client && npm run build --workspace @lightspeed/configurator-mcp && npm run build --workspace @lightspeed/platform-web",
     "build:web": "npm run build --workspace @lightspeed/platform-web",
     "check": "npm run check:dev && npm run check:identity && npm run check:generated && npm run typecheck && npm run test && npm run build",
-    "check:ci": "npm run check && npm run test:migrations && npm run test:integration:channels && npm run test:integration:bots",
+    "check:ci": "npm run check && npm run test:migrations && npm run test:integration:channels && npm run test:integration:bots && npm run test:release-packaging",
     "check:dev": "bash -n dev.sh scripts/dev/env.sh scripts/dev/lib/common.sh scripts/dev/infra/*.sh && node --check scripts/dev/stack.mjs && ./dev.sh --help >/dev/null && LIGHTSPEED_CHANNELS_CONNECTORS= node scripts/dev/stack.mjs --plan infra >/dev/null && LIGHTSPEED_CHANNELS_CONNECTORS= node scripts/dev/stack.mjs --plan runtime >/dev/null && LIGHTSPEED_CHANNELS_CONNECTORS= node scripts/dev/stack.mjs --plan platform >/dev/null && LIGHTSPEED_CHANNELS_CONNECTORS= node scripts/dev/stack.mjs --plan full >/dev/null",
     "check:identity": "node platform/scripts/check-product-identity.mjs",
     "check:generated": "npm run check:generated --workspace @lightspeed/agent-client && npm run check:generated --workspace @lightspeed/configurator-mcp && node platform/scripts/generate-config-reference.mjs && git diff --exit-code -- platform/web/src/lib/profile-config-reference.ts",
@@ -27,6 +27,7 @@
     "test:integration:bots": "npm run test:integration --workspace @lightspeed/bots",
     "test:integration:channels": "npm run test:integration --workspace @lightspeed/channels",
     "test:migrations": "npm run test:migrations --workspace @lightspeed/platform-db",
+    "test:release-packaging": "npm --prefix clients/typescript ci --ignore-scripts && npm --prefix platform/configurator-mcp ci --ignore-scripts && scripts/release/stage-runtimes.sh",
     "typecheck": "tsc --noEmit && npm run typecheck --workspace @lightspeed/bots && npm run typecheck --workspace @lightspeed/channels && npm run typecheck --workspace @lightspeed/platform-web && npm run typecheck --workspace @lightspeed/agent-client && npm run typecheck --workspace @lightspeed/configurator-mcp"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- update the standalone TypeScript client lock for its new @noble/hashes dependency
- add the standalone installs and runtime staging to check:ci so this exact release boundary cannot regress

## Validation
- reproduced the protected Linux release failure in node:24.13.0-bookworm-slim
- full Linux npm build + standalone installs + both runtime stages now succeeds
- npm run test:release-packaging