### PR TITLE
Add bot environments and terminal lifecycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -428,9 +428,30 @@ Release construction, snapshots, and tagged publication are documented in
   environment's staged `idlePolicy` (pause → suspend → stop → close, skipping
   stages the provider lacks). A powered-down provisioned environment wakes on
   use: the resolver sets desired `running` and reports `NotReady`, reusing the
-  P125 `await_environment_ready` path. Do not add per-call `lastUsedAt`
-  writes, provider-side policy, or feature-specific pause/resume verbs. See
-  `docs/roadmap/p126-environment-power-and-idle-policy.md`.
+  P125 `await_environment_ready` path. The power decision never consults
+  sessions — the daemon's idle report is the only activity signal, so N
+  sessions (of any bot or client) sharing an environment need no
+  coordination — and use cancels a pending power-down (a `ready`
+  environment whose `desiredPower` is lower is written back to `running`
+  at resolution). Do not add per-call `lastUsedAt` writes, provider-side
+  policy, a session→environment index, or feature-specific pause/resume
+  verbs. See `docs/roadmap/p126-environment-power-and-idle-policy.md`.
+- A bot's environment is the profile's `existing` environment (P140): a
+  universe resource nothing bot-related creates, closes, or deletes; its
+  idle policy lives on the environment and is edited there. Per-session
+  `provision` remains the sandbox-per-event choice. Do not add bot- or
+  controller-scoped provisioning, generations, shared scopes, or leases —
+  a first version of P140 tried and was reverted.
+- Bots have three lifecycle states (P140): `disabled` is the reversible
+  pause (sessions and chat context stay, the environment sleeps by idle
+  policy); `close` is terminal — the server writes `closedAt` first, disables
+  every trigger (`bot_closed`), and the controller archives what is pending,
+  force-closes every session, records `closedSessions`, and completes
+  instead of continuing as new; `delete` closes first, `session/delete`s
+  the recorded sessions, and removes the row so the name is free. Admission
+  refuses on the row (`closedAt`) — waking is a signal-with-start, so
+  nothing else stops a late event from resurrecting a closed controller.
+  Do not add a reopen, a drain period, or a second lifecycle authority.
 - Preserve Rust 2024 and the existing crate-local `thiserror` error style.
 - Use `tokio` current-thread tests where async tests are needed.
 

--- a/crates/cli/src/profile_cli.rs
+++ b/crates/cli/src/profile_cli.rs
@@ -617,11 +617,30 @@ async fn validate_environments(
         .into_iter()
         .map(|binding| (binding.binding_id.clone(), binding))
         .collect::<BTreeMap<_, _>>();
-    if environment.status != EnvironmentLifecycleStatusView::Ready {
-        report.warning(format!(
-            "profile environment is {:?}, not ready",
+    match environment.status {
+        EnvironmentLifecycleStatusView::Ready => {}
+        EnvironmentLifecycleStatusView::Closing
+        | EnvironmentLifecycleStatusView::Closed
+        | EnvironmentLifecycleStatusView::Failed => report.error(format!(
+            "profile environment {environment_id} is {:?}; applying the profile will be rejected until it points at an open environment",
             environment.status
-        ));
+        )),
+        status => report.warning(format!("profile environment is {status:?}, not ready")),
+    }
+    // A long-lived box (a bot's, or one shared by several sessions) sleeps
+    // only through its own idle policy; nothing on the profile can add one.
+    match &environment.source {
+        EnvironmentSourceView::Provisioned { .. } if environment.idle_policy.is_none() => {
+            report.warning(format!(
+                "profile environment {environment_id} has no idle policy: it never pauses, suspends, or stops while idle (set one with `env idle-policy` or on the Environments page)"
+            ));
+        }
+        EnvironmentSourceView::External { .. } => {
+            report.warning(format!(
+                "profile environment {environment_id} is external: no power control, so it can never be paused or stopped while idle"
+            ));
+        }
+        _ => {}
     }
     if let EnvironmentSourceView::Provisioned { binding_id, .. } = &environment.source {
         match bindings.get(binding_id) {

--- a/crates/temporal-server/src/environment_resolver.rs
+++ b/crates/temporal-server/src/environment_resolver.rs
@@ -201,6 +201,23 @@ impl EnvironmentResolver {
                     environment_id: environment.environment_id.as_str().to_owned(),
                 });
             }
+            EnvironmentStatus::Ready if environment.desired_power != PowerState::Running => {
+                // Use cancels a pending power-down: the idle reaper has asked
+                // for a lower power state but the reconciler has not converged
+                // yet. Keeping the intent at `running` stops the reconciler
+                // from freezing the environment under the call about to
+                // start; the reaper re-evaluates from the daemon's next idle
+                // report. Sessions are not consulted — any use counts.
+                return self
+                    .environments
+                    .set_environment_power(SetEnvironmentPower {
+                        environment_id: environment.environment_id.clone(),
+                        desired_power: PowerState::Running,
+                        updated_at_ms: now_ms.max(0),
+                    })
+                    .await
+                    .map_err(EnvironmentResolveError::from);
+            }
             EnvironmentStatus::Ready
             | EnvironmentStatus::Paused
             | EnvironmentStatus::Suspended
@@ -373,6 +390,42 @@ mod tests {
             resolver.selectable(&environment_id, None, 111).await,
             Err(EnvironmentResolveError::EnvironmentUnavailable { .. })
         ));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn use_cancels_a_pending_power_down() {
+        let (resolver, environment_id) = resolver().await;
+        let store = resolver.environments.clone();
+        store
+            .observe_provisioned_environment(ObserveProvisionedEnvironment {
+                environment_id: environment_id.clone(),
+                provider_target_id: ProviderTargetId::new("target-1"),
+                status: EnvironmentStatus::Ready,
+                power_states: vec![PowerState::Running, PowerState::Paused],
+                observed_at_ms: 20,
+            })
+            .await
+            .expect("observe");
+        // The reaper decided to pause; the reconciler has not acted yet.
+        store
+            .set_environment_power(SetEnvironmentPower {
+                environment_id: environment_id.clone(),
+                desired_power: PowerState::Paused,
+                updated_at_ms: 21,
+            })
+            .await
+            .expect("pause intent");
+
+        let resolved = resolver
+            .resolve_for_connection(&environment_id, None, 30)
+            .await
+            .expect("a ready environment resolves for use");
+        assert_eq!(resolved.status, EnvironmentStatus::Ready);
+        assert_eq!(resolved.desired_power, PowerState::Running);
+        let stored = store.read_environment(&environment_id).await.expect("read");
+        assert_eq!(stored.desired_power, PowerState::Running);
+        assert!(!stored.power_diverges());
+        assert_eq!(stored.updated_at_ms, 30);
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/docs/roadmap/p130-bots.md
+++ b/docs/roadmap/p130-bots.md
@@ -232,6 +232,12 @@
   - Tests: tool round trip via a fake session workflow (reply observed,
     redelivery ignored), rotation on mismatch, declaration shape, arg
     mapping, schedule spec validation; nine Temporal integration scenarios.
+- 2026-08-27: a bot's environment is the profile's `existing` environment,
+  shown on the bot page with its idle policy; exec pollers default to it;
+  bots gained a terminal `close` and a `delete` that closes first — see
+  [P140](p140-bot-environments-and-bot-lifecycle.md). The controller's
+  `EXTRA_SESSION_CAP` eviction now closes the evicted session instead of
+  forgetting it.
 - Next: the trigger long tail — poll primitive, agent-authored pollers,
   email, more presets, Channels bridge — extracted 2026-08-24 into its own
   doc, [P131](p131-bot-trigger-long-tail.md). Still open here: secret

--- a/docs/roadmap/p131-bot-trigger-long-tail.md
+++ b/docs/roadmap/p131-bot-trigger-long-tail.md
@@ -115,7 +115,9 @@ guardrails apply (grant-gated trigger_put, 60s minimum interval, breaker,
 10-failure auto-disable, budgets, visible cursor, `self_configured`
 activity trail). Best with a stable `existing`-environment profile —
 per-session provisioned environments close with their session and would
-strand the trigger. What remains of this workstream is only: an approval
+strand the trigger. Since [P140](p140-bot-environments-and-bot-lifecycle.md)
+an exec trigger may omit `environmentId` and runs in that profile's
+`existing` environment. What remains of this workstream is only: an approval
 gate if operator policy ever wants one, and resident daemons (below).
 Original sketch:
 

--- a/docs/roadmap/p140-bot-environments-and-bot-lifecycle.md
+++ b/docs/roadmap/p140-bot-environments-and-bot-lifecycle.md
@@ -1,0 +1,511 @@
+# P140 — Bot Environments and Bot Lifecycle
+
+**Status**
+
+- **Implemented 2026-08-27 (v2), all four slices**; reviewed by Lukas
+  before implementation (two nits folded in: per-session `provision` stays a
+  valid bot choice; the Environments page needed an idle-policy editor). See
+  the implementation notes under Slices. Still open: a live dogfood of bot
+  close/delete and of the idle-policy modal on the dev stack.
+- Decisions taken with Lukas, in order:
+  1. A bot's environment is, most of the time, an **`existing`**
+     environment. Profiles keep exactly the intents they have today —
+     `existing`, per-session `provision`, `inherit` — and nothing is added
+     to the core's environment model. One environment per bot, one per team
+     of bots, or a box an interactive session joins are all the same
+     configuration: create the environment once, point profiles at its id.
+     Per-session `provision` stays available to bots for the sandbox-per-
+     event case (one VM per routed or event session, closed with it); it
+     already works and is the exception, not the default.
+  1a. **Existing environments need an idle-policy editor.** The Environments
+     page only displays the policy today; the `environments/idle-policy/put`
+     route exists but has no UI. A per-environment modal (and the same
+     fields in the create dialog) is part of this proposal.
+  2. **Power needs nothing new.** An idle policy is a property of the
+     environment record ([P126](p126-environment-power-and-idle-policy.md)),
+     applied by the reaper to every `ready` provisioned-source environment
+     whoever references it, and wake-on-use fires for any session that
+     activates a powered-down one. An `existing` bot box therefore already
+     pauses, suspends, stops, and wakes. Only *external* environments (a
+     daemon you bring) have no power control.
+  3. Keep one core hardening from v1: **use cancels a pending power-down**
+     (the reaper-vs-first-use race, §3).
+  4. Bots get a lifecycle that mirrors sessions: `disabled` stays the
+     reversible pause; **`close`** is terminal (releases sessions and
+     schedules, keeps history); **`delete`** erases and frees the name, and
+     closes first if needed. Close cancels in-flight runs immediately; a bot
+     never closes or deletes an environment.
+  5. Everything else is convenience on the platform: an environment card on
+     the bot page, exec pollers defaulting to the bot's environment, editor
+     and `profiles check` hints.
+- **v1, same day, reverted.** The first P140 added
+  `provision { scope: controller }` — one environment keyed off the managed
+  session's lifecycle controller, request id
+  `controller:<sha256(scope)>:g<n>`, generations replacing a closed one — and
+  was implemented end to end (five slices, `bot-envs` commits `37fb5652`
+  and `66b2b9e9`). It was thrown away (`git reset --hard 5033e523`) when
+  "what if different bots share an environment?" showed the lifecycle
+  controller is the wrong grouping axis: it gives one box per bot by
+  construction, and the fix on that path (a third `shared` scope with a
+  key) was more model for something `existing` already does. Nothing of v1
+  is kept except the resolver hardening and the bot lifecycle design.
+- Builds on [P125](p125-profile-provisioned-environments.md) (intents,
+  `originSession`, `await_environment_ready`), P126 (power intent, idle
+  reaper, wake-on-use), [P130](p130-bots.md) (controller, routed sessions,
+  rotation, retention), [P134](p134-subagents.md) (`inherit`, lineage),
+  [P135](p135-bot-federation.md) (directory, `bot_emit` refusals), and
+  [P139](p139-channels-as-bot-triggers.md) (chat triggers, never-expiring
+  chat sessions).
+
+## Why
+
+A bot is a session factory: `resolveBotProfile` passes the profile's
+`environment` intent through verbatim (`platform/bots/src/contracts/bots.ts`)
+into every `session/managed/start` the controller makes
+(`platform/bots/src/activities/lightspeed.ts`) — the main session and its
+rotated generations, every routed session, every chat conversation. Each is a
+separate core session that applies the profile on its own.
+
+With per-session `provision` that is one VM per session whose state dies
+with the session: main-session rotation discards it, the routed-session
+retention sweep closes one per key, a chat conversation (never expires) pins
+one per conversation. That is the right shape for a bot whose job is a
+disposable sandbox per event, and the wrong default for the common bot,
+which wants one durable box. Exec pollers are stranded on it, and the bot
+page today tells the operator to "point the profile at an existing
+environment" as if that were a workaround. It is not — it is the design.
+What the codebase lacks is treating it as such: nothing shows a bot's
+environment next to the bot, exec pollers have to be handed an id, the
+Environments page can display an idle policy but not set one on an existing
+environment, the editor and CLI give no hint that the policy lives there,
+and there is no way to retire or delete a bot at all
+(`platform/server/src/routes/bots.ts` has create and patch only;
+`enabled: false` pauses).
+
+## Today
+
+- `ProfileEnvironment` (`crates/api/src/profiles.rs`): `existing`, `inherit`
+  (sub-agents), `provision { providerId, templateId, retention, idlePolicy?,
+  credentials? }` with `requestId = "session:" + sessionId` and an optional
+  `closeWithSession` trigger on `originSession`.
+- The applier (`crates/temporal-server/src/gateway/service/profiles.rs`)
+  activates an `existing` environment through the same status-aware
+  admission as `session/environments/activate`: `provisioning`/`booting`
+  and powered-down environments are admitted as intent (P125/P126),
+  `closing`/`closed`/`failed` are rejected with a typed error.
+- Idle policy and power intent live on the environment record
+  (`crates/environments/src/lib.rs`, `EnvironmentRecord.{desired_power,
+  idle_policy}`); set at `environments/create`, changed with
+  `environments/idle-policy/put` and `environments/power/put`, and shown
+  with Resume/Pause/Suspend/Stop on the Environments page. The reaper
+  (`environment_power.rs`, `decide_idle_action`) reads the daemon's
+  `env/idle` report — `{ idleForMs, runningProcesses, runningJobs }` on one
+  monotonic clock bumped by every data-plane request — and never consults
+  sessions. Wake-on-use keys on `EnvironmentSource::Provisioned`
+  (`environment_resolver.rs`, `wake_on_use_applies`), not on who
+  provisioned it.
+- The bot controller (`platform/bots/src/workflows/bot-controller.ts`)
+  tracks its sessions in memory (main generation, `extraSessions` capped at
+  `EXTRA_SESSION_CAP = 200`, per-key generations), closes routed sessions by
+  TTL, and closes descendants first through `closeBotSession` (non-force).
+  Admission re-reads the bot row and refuses when `enabled` is false
+  (`platform/bots/src/admission.ts`); `wakeBotController` is a
+  `signalWithStart` (`platform/bots/src/events.ts`).
+- `session/close { force }` cancels the active run and drops queued runs;
+  `session/delete` on an open session force-closes first, then removes the
+  record (`crates/temporal-server/src/gateway/service/mod.rs`).
+
+## Design — Part A: a bot's environment is an `existing` environment
+
+### 1. The configuration
+
+```text
+1. Environments page (or `environments/create`): one box from a provider
+   template, with an idle policy — e.g. pause after 10 min, stop after 6 h,
+   no close stage. Bind credentials on it if the bot needs any.
+2. Profile: environment: { type: "existing", environmentId: "<that id>" },
+   config granting features.environments (jobs: true for job tools).
+3. Bot: profileId = that profile.
+```
+
+- One box per bot: one environment, one profile, one bot. One box for a
+  team of bots: one environment, N profiles (or one shared profile), N
+  bots. An operator who wants to poke at the box interactively starts a
+  session with the same profile, or activates the environment by id.
+- Sub-agents that should work on the bot's box use a profile with
+  `environment: { type: "inherit" }` and the environments grant; children
+  that should be isolated use per-session `provision`. Unchanged from P134.
+- A bot whose work is a sandbox per event keeps per-session `provision`
+  (default `closeWithSession`): one VM per routed or event session, gone
+  with it, exactly as today. Nothing here changes that path; the bot page's
+  warning about exec pollers stays because it is true for it.
+- Nothing on the bot record references an environment. The profile is the
+  only link, exactly as for any session, and `resolveBotProfile` keeps
+  passing it through untouched.
+
+Rejected (v1): a `provision { scope: controller }` that auto-creates one
+environment per bot with generations. It cannot express a box shared by
+several bots, needs a scope column, a request-id scheme, generation
+lookup, a pre-start rejection for plain sessions, and a second creation
+path for exec pollers — all to save one `environments/create`. Also
+rejected on the same grounds: a `shared` scope keyed by name, a
+caller-supplied scope key on `session/managed/start`, a lease/ref-count that
+closes a box when its last session leaves, and a bot record in the core.
+
+### 2. Power: nothing to add, and why it is safe with many sessions
+
+"Safe to pause" is, and stays, `runningProcesses == 0 && runningJobs == 0 &&
+idleForMs >= threshold` from the daemon's report:
+
+- Every session's `fs/*`, `process/*`, `job/*` call — main, routed, chat,
+  sub-agent, another bot's session, an operator shell, an exec poll job —
+  touches the same clock, so N sessions sharing a box need no coordination;
+  the union is computed by construction. That is precisely why P126 chose
+  the daemon over session-derived idleness.
+- A background process started by any session pins the box awake. Right:
+  freezing it is harmless, `stopped` would kill it.
+- An LLM-only turn is not use. A session mid-run can have its box paused
+  underneath it; its next environment tool call gets `NotReady`, the
+  workflow waits in `await_environment_ready`, and the call is
+  re-dispatched. Stage the policy accordingly: `pause` (freeze,
+  milliseconds to resume) after minutes, `suspend`/`stop` after hours.
+- Exec poll jobs count as activity and wake a sleeping box (P131's patch);
+  a poll interval shorter than `pauseAfterMs` keeps it awake, longer cycles
+  it — fine for freeze, wasteful for `stopped`.
+
+Rejected: any session→environment index so the reaper could skip boxes
+whose sessions have a running run. A chat session is effectively always
+open and a run can be a two-hour LLM-only turn; the proxy would keep boxes
+awake for nothing and is blind to non-session use.
+
+### 3. Use cancels a pending power-down (core, kept from v1)
+
+The one race in P126: the reaper reads "quiescent" and sets
+`desiredPower: paused`; a session starts work before the reconciler
+converges; the reconciler freezes the box under the call. P126 accepted it
+(the P114 activity deadline fires, the retry sees `paused` and wakes it).
+This narrows it: in `resolve_for_connection`, a `ready` environment whose
+`desiredPower != running` gets one conditional write back to `running`
+before the call proceeds — the same shape as the wake branch, still
+session-blind, independent of how the environment is referenced. Unit test
+in `environment_resolver.rs`; no wire change.
+
+### 4. When the box goes away
+
+An `existing` environment that is `closing`/`closed`/`failed` fails the next
+profile apply with a typed error, so a new bot session cannot start and the
+controller reports `degraded`. There is no automatic replacement — no
+generations — and that is the accepted trade:
+
+- **Rule: no `closeAfterMs` on a bot box.** `stop` is the deepest stage; a
+  stopped environment costs only disk and comes back on the next use. A
+  box disappears only when an operator closes it.
+- When an operator does replace a box: create the new one, edit the
+  profile's `environmentId`; the controller re-applies the profile on the
+  next revision change, and every bot session moves over (a session's
+  active environment changes on apply).
+- The bot page shows the environment's status prominently, so a closed
+  box is visible next to the bot, not buried in a session error.
+
+### 5. Platform conveniences
+
+- **Idle policy editor on the Environments page.** Today
+  `EnvironmentsPage.tsx` renders the policy read-only and the create dialog
+  has no policy fields, while `PUT /api/v1/universes/:id/environments/:id/
+  idle-policy` (→ `environments/idle-policy/put`) already exists. Add an
+  "Idle policy" modal on every provisioned environment row — the four
+  stages in minutes with the monotone check, "clear" as an explicit
+  action — and the same fields in the create dialog. The stage inputs move
+  out of `profile-environment-editor.tsx` (`IdlePolicyFields`) into a shared
+  `components/environment/idle-policy-fields.tsx` so the profile editor,
+  the create dialog, and the modal render one thing. External environments
+  and closed ones do not offer it (the core rejects it for them).
+- **Bot page environment card**: for a profile with `existing`, show the
+  environment (status, desired power with the converging arrow, idle
+  policy, template) with the Environments page's Resume/Pause/Suspend/Stop
+  controls (moved into a shared `components/environment/power-controls.tsx`)
+  and a link to the page. Amber hint when the environment has no idle
+  policy ("this box never sleeps") or is external ("no power control").
+  Red when it is closed/failed. The existing per-session warning stays for
+  `provision` profiles.
+- **Exec pollers** (P131): `environmentId` becomes optional on the poll
+  spec, `bot_trigger_put`, and the web form; at fire time it resolves to the
+  bot profile's `existing` environment, and a bot whose profile is not
+  `existing` gets a clear configuration error (not a transient failure).
+  The "Command poll" card is enabled exactly when the profile is `existing`
+  (as today).
+- **Profile editor**: the `existing` mode description says where the idle
+  policy lives and links to the Environments page; the environment option
+  labels carry the environment's power/idle state. The `provision` label
+  says "for the session".
+- **`profiles check`**: for `existing`, warn when the environment has no
+  idle policy or is external; error when it is closed (today's typed
+  read error already covers "missing").
+
+## Design — Part B: bot lifecycle
+
+### 6. Three states, two of which exist
+
+| state | reversible | live resources | history | name |
+| --- | --- | --- | --- | --- |
+| **disabled** (exists) | yes | kept: sessions and chat context stay; the environment sleeps by idle policy | kept | reserved |
+| **closed** (new) | no | released: sessions closed, schedules dropped, triggers disabled | readable | reserved |
+| **deleted** (new) | — | — | erased | freed |
+
+Disable cannot double as close: it must preserve chat conversations and
+routed-session context for re-enable. Close earns its own state because it
+is cheap (delete needs the same teardown; the state is one `closedAt`
+column plus "reject `enabled: true` while closed") and because "this bot is
+done, keep what it did" is a real operator request — the same reason
+`session/close` exists next to `session/delete`. Like `session/delete`,
+`delete` on an open bot closes first, so it stays one call when nobody
+cares about the distinction.
+
+A bot never closes or deletes an environment: its box is an `existing`
+universe resource other sessions or bots may share; a per-session
+provisioned environment closes with its session through the core.
+
+### 7. Close
+
+`POST /api/v1/universes/:id/bots/:botId/close`. The server writes
+`closedAt` (and `enabled = false`) **first**, so every later step is
+idempotent and retry-safe, then:
+
+1. **Server**: set every trigger `enabled = false` with `disabledReason:
+   "bot_closed"` and reconcile schedules (paused; deleted at delete time —
+   chat triggers stop matching on their account, other bots' triggers on
+   the same account are untouched). Admission refuses on `closedAt` the
+   same way it refuses on `enabled`: webhooks answer `410`, the manual
+   event route `410`, `bot_emit` to a closed bot returns a typed
+   `bot_closed` refusal (distinct from `bot_disabled`, so a sending model
+   stops retrying), schedule and poll fires exit on the disabled trigger,
+   the `bot:directory` catalog omits it (close sets `enabled = false`).
+   The resurrection guard matters: `wakeBotController` is a
+   `signalWithStart`, so `storeBotEvent` must refuse on the row before
+   anything is stored — otherwise a late webhook would start a fresh
+   controller for a bot that no longer exists.
+2. **Controller**: `BotStartV1` gains `closed?: boolean`; the config signal
+   (or a `signalWithStart`, if the workflow is gone — the teardown then runs
+   in a fresh run, which is exactly what restart safety wants) makes the
+   controller stop dispatching and run the teardown as activities:
+   - buffered, pending, and in-flight events get outcome `archived`,
+     detail `bot_closed`; active lanes are not waited for — they lose their
+     session underneath and settle on their own;
+   - every session it knows — main generations `1..N` and every tracked
+     routed session — is closed with `force: true`, descendants first
+     inside the activity (`closeBotSession` grows a `force` flag; an
+     already-closed session counts as done);
+   - the controller records its final session set on the bot row
+     (`bots.closed_sessions jsonb`, union with any earlier attempt) — the
+     authority on generations is the controller, and after it returns
+     nothing else knows them;
+   - the workflow **returns** instead of continue-as-new;
+     `controllerStatus` reports `closing` / `closed`. The server's close
+     route awaits the run result with a bounded timeout (30 s) and answers
+     `{ bot, completed }`; a timeout still leaves `closedAt` set and the
+     next close call re-signals.
+3. `PATCH { enabled: true }` on a closed bot is `409`; label patches
+   (display name, description) stay allowed and do not signal the
+   controller.
+
+Pre-existing gap fixed on the way: `ensureRoutedSession` evicts sessions
+beyond `EXTRA_SESSION_CAP` from memory without closing them, so they leak
+out of the retention sweep and out of any teardown. Eviction closes the
+session (non-force; a busy one stays tracked until the next sweep) and
+bumps its generation.
+
+### 8. Delete
+
+`DELETE /api/v1/universes/:id/bots/:botId`. If the bot is open, run the
+close procedure first and wait for it (`409` while the teardown has not
+completed). Then:
+
+1. `session/delete` every id in `closed_sessions` (`not_found` is fine — a
+   rotation that was never ensured). Sessions must go: their ids derive
+   from the immutable bot name, so a re-created bot would collide with its
+   predecessor's closed sessions at `session/managed/start`. Sub-agent
+   descendants were closed at close time; their ids (`agent_<digest>`) do
+   not derive from the bot name, and their records stay as history.
+2. Delete each trigger through `deleteTrigger` (drops its Temporal
+   Schedule), then the `bots` row; `bot_events` and `channel_pairings`
+   follow by cascade. The name is free.
+3. Environments are untouched. The completed controller workflow id is
+   reusable under Temporal's default reuse policy.
+
+### 9. Rules
+
+- A bot's environment is the profile's `existing` environment: a universe
+  resource nothing bot-related creates, closes, or deletes.
+- The reaper never consults sessions. Use — any data-plane request from
+  anyone — is the only activity, and use cancels a pending power-down.
+- No `closeAfterMs` on a bot box; `stop` is the deepest stage.
+- `disabled` is reversible and keeps sessions; `closed` is terminal and
+  releases them; `deleted` erases. Nothing revives a closed bot.
+- Close writes `closedAt` before any teardown step; every step is
+  idempotent; admission refuses on the row, never on controller state.
+- Bot `delete` closes first.
+
+## What is deliberately not built
+
+- Any new environment intent or scope (controller, shared, named), request
+  id scheme, generations, or provenance column (v1, reverted).
+- Auto-creation of a bot's environment from the bot record.
+- A lease/ref-count that closes a box when its last session leaves.
+- Session-aware power decisions or a session→environment index.
+- A grace period or drain before close cancels runs (default: immediate;
+  revisit if a bot's runs turn out to be long transactions worth
+  finishing).
+- `bots/reopen`; deleting environments or sub-agent history with a bot.
+- Operator CLI commands for bots — the CLI has none today and this adds
+  none; routes and the web UI are the surface.
+
+## Wire and record changes
+
+Core `api`: **none.** The resolver change (§3) alters behavior, not the
+contract.
+
+Platform (`platform/db`, folded into the pre-release `0002_bots` baseline
+with the snapshot-patch trick from P135): `bots.closed_at timestamptz`,
+`bots.closed_sessions jsonb`; `bot_triggers.disabled_reason` takes
+`bot_closed`. `BotView` gains `closedAt` and `closedSessions`.
+`BotStartV1.closed?: boolean`. `BotSnapshot.controllerStatus` gains
+`closing` / `closed`. Poll spec `source.environmentId` becomes optional.
+
+## Runtime and platform changes
+
+- `crates/temporal-server/src/environment_resolver.rs`: `ready` +
+  `desiredPower != running` → conditional write back to `running`.
+- `crates/cli` `profiles check`: `existing` idle-policy / external / closed
+  hints.
+- `platform/bots`: admission refusal code `bot_closed` (`resolveInbox`,
+  `storeBotEvent`); controller `closed` handling (`teardown()`, `wake()`
+  fires on it even under an active lane, return instead of continue-as-new,
+  eviction closes); `closeBotSession { force }`; `recordBotClosed`
+  activity; poll fire resolves a missing `environmentId` from the bot
+  profile; `bot_trigger_put` and its schema description accept the
+  omission.
+- `platform/server`: `bots/:botId/close`, `DELETE bots/:botId`, `409` on
+  enabling a closed bot, `410` on webhook ingest and manual events for a
+  closed bot; `signalBotConfig` carries `closed`.
+- `platform/web`: Environments page idle-policy modal and create-dialog
+  fields (shared `idle-policy-fields.tsx`); bot page environment card;
+  shared power controls; Close
+  and Delete in the bot settings dialog (Close confirms irreversibility;
+  Delete explains close-first); "Closed" on the bots list and a closed note
+  on the detail page; trigger cards show "bot closed"; poll form with an
+  optional environment; profile editor copy.
+
+## Slices
+
+1. [x] **Core hardening** — resolver "use cancels a pending power-down" with a
+   unit test. Tiny; no contract change.
+2. [x] **Environment surfaces** — idle-policy editor modal and create-dialog
+   fields on the Environments page, bot page environment card (shared
+   power controls), exec poll default, editor copy, `profiles check` hints.
+3. [x] **Bot close and delete** — platform columns, admission guards,
+   controller teardown, routes, web dialogs, integration scenarios.
+4. [x] **Docs** — `AGENTS.md` (rules in §9), `docs/spec/04-environments.md`
+   (a paragraph on shared use and the power-down cancel), P130 status note,
+   P131 §3 note (exec pollers default to the bot's environment). `README.md`
+   needed no change: its profiles bullet already describes `existing` and
+   per-session `provision`.
+
+### Implementation notes (2026-08-27)
+
+- **Core**: `resolve_for_connection` on a `ready` environment whose
+  `desiredPower != running` writes the intent back to `running` and
+  proceeds (`environment_resolver.rs`, test
+  `use_cancels_a_pending_power_down`). No `api` change; the contract
+  artifacts are untouched.
+- **Environments page**: `components/environment/power-controls.tsx`
+  (power helpers and Resume/Pause/Suspend/Stop, moved out of the page),
+  `components/environment/idle-policy-fields.tsx` (the four stages plus
+  `idlePolicyIsMonotone`, moved out of the profile editor and shared by
+  the profile editor, the create dialog, and the new modal), and
+  `components/environment/idle-policy-dialog.tsx` (`PUT
+  …/environments/:id/idle-policy`, explicit Clear, amber hint when empty,
+  warning on a close stage). The environment card gets an "Idle policy…"
+  button on open provisioned environments; the create dialog gets the stage
+  fields (`idlePolicy` was already forwarded by the server route) and a
+  hint that a shared box should at least pause.
+- **Bot page**: `components/bot/environment-card.tsx` for `existing`
+  profiles — status, power convergence, idle policy, power controls, the
+  idle-policy modal, and red/amber notes for a closed, policy-less, or
+  external environment. `DetailSection` moved to `bot/status.tsx`. The
+  per-session `provision` warning stays and now says "a sandbox per event".
+- **Exec pollers**: `environmentId` optional end to end (zod schema, row
+  type, `bot_trigger_put` mapping and tool descriptions, web form and
+  validation); `resolveBotProfileEnvironment` in `activities/poll.ts`
+  reads the bot's profile at fire time and uses its `existing` id, failing
+  with a configuration error for any other intent.
+- **CLI `profiles check`**: an `existing` environment that is
+  closing/closed/failed is an error; a provisioned one without an idle
+  policy, or an external one, is a warning.
+- **Bot lifecycle**: exactly the v1 build minus any environment step —
+  `bots.closed_at` / `bots.closed_sessions` folded into the `0002_bots`
+  baseline (snapshot patched, no-op `drizzle-kit generate`,
+  `test:migrations` asserts both); `bot_closed` refusal from `resolveInbox`
+  and `storeBotEvent`; `410` on webhook ingest and manual events;
+  controller `teardown()` (archive → force-close every known session →
+  `recordBotClosed` → return; `closing`/`closed` status; `wake()` fires on
+  it under an active lane; `EXTRA_SESSION_CAP` eviction closes the
+  session); `POST …/close` (row first, triggers `bot_closed`, schedules
+  paused, signal, ≤ 30 s wait, `completed`); `DELETE …` (close first, `409`
+  while pending, `session/delete` recorded sessions, `deleteTrigger` per
+  trigger, row cascade); `PATCH` labels-only on a closed bot; web
+  Lifecycle block with Close/Delete confirms, "Closed" on list/detail,
+  "bot closed" on trigger cards.
+- **Verified**: `cargo test -p temporal-server --lib environment_resolver`,
+  `cargo clippy -p temporal-server -p cli --all-targets`, `npm run
+  typecheck/test/build`, `check:identity`, `test:migrations` against a
+  scratch platform database, bots Temporal integration 18/18 including
+  the new close scenario (pending event archived `bot_closed`, forced
+  session close, sessions recorded, `COMPLETED`, history replays, second
+  signal-with-start tears down again without creating a session).
+- **Deploy note**: the platform `0002_bots` baseline changed → existing dev
+  databases need `./dev.sh reset`. The core `005_environments` baseline is
+  untouched (v1's column is gone with v1).
+
+## Tests
+
+Core unit: resolver `ready` + pending power-down flips desired back to
+`running` and proceeds; the powered-down wake branch is unchanged.
+
+Bots unit: `resolveInbox` refuses `bot_closed` before `bot_disabled`;
+`bot_trigger_put` maps an exec poll without `environmentId`; the poll
+activity's environment resolution picks the profile's `existing` id and
+fails clearly otherwise.
+
+Bots integration (`BOTS_TEMPORAL_INTEGRATION=1`, `npm run
+test:integration:bots`):
+
+- close: a disabled bot with a pending event receives `closed` → the event
+  ends `archived` / `bot_closed`, the main session is closed with
+  `force: true`, `closed_sessions` is recorded, the workflow `COMPLETED`,
+  history replays; a second signal-with-start with `closed` tears down
+  again without creating a session;
+- eviction beyond `EXTRA_SESSION_CAP` closes the evicted session.
+
+Platform: `test:migrations` asserts `closed_at` and `closed_sessions` on
+fresh and upgrade paths. Consumers: `npm run check`.
+
+Live (dev stack, manual): create a box, set its idle policy from the new
+modal, point a bot at it, watch the bot page card pause it after the
+threshold and wake it on the next event; close the bot and confirm the box
+stays; delete the bot and re-create it under the same name.
+
+## Open questions
+
+1. Whether `close` should offer an opt-in drain (`{ drainMs }`) for bots
+   whose runs perform multi-step external writes. Default is immediate
+   cancel.
+2. Whether the Environments page's create dialog should suggest a default
+   idle policy (P126 open question 2 again). For now the bot page and
+   `profiles check` warn.
+
+## Deferred
+
+- Pre-wake on `runs/start` for a powered-down active environment (an
+  optimization, not safety).
+- Deleting sub-agent descendants' records with the bot.
+- `bots/reopen`.

--- a/docs/roadmap/roadmap.md
+++ b/docs/roadmap/roadmap.md
@@ -1,6 +1,20 @@
 # Lightspeed Roadmap
 
 ## Work
+- [x] [P140](p140-bot-environments-and-bot-lifecycle.md) — bot environments
+  and bot lifecycle (implemented 2026-08-27, v2; live dogfood of
+  close/delete still open): a bot's
+  environment is the profile's `existing` environment — idle policy and
+  wake already apply to it (P126), so nothing is added to the core's
+  environment model (per-session `provision` stays for sandbox-per-event
+  bots); one core hardening ("use cancels a pending power-down" in the
+  resolver); an idle-policy editor on the Environments page, bot page
+  environment card, exec pollers defaulting to the bot's environment; bots
+  get `close` (terminal:
+  archives pending events, force-closes sessions, drops schedules, keeps
+  history) and `delete` (closes first, erases, frees the name). A first
+  version with `provision { scope: controller }` and generations was
+  implemented and reverted the same day.
 - [x] [P139](p139-channels-as-bot-triggers.md) — Channels as bot triggers
   (implemented 2026-08-26): a chat connection is a `chat` trigger on a bot,
   `channel_bindings` is deleted, every message is an admitted event

--- a/docs/spec/04-environments.md
+++ b/docs/spec/04-environments.md
@@ -60,6 +60,16 @@ before the environment is ready do not fail: the worker reports the call as
 not executed, the session workflow waits in a heartbeated
 `await_environment_ready` activity, and re-dispatches the call.
 
+Long-lived clients — a bot's main, routed, rotated, and chat sessions, or
+several bots — share an environment by naming the same `existing` id in
+their profiles. Nothing coordinates them: idleness is the daemon's fact, so
+the reaper powers the environment down when none of its users touch it and
+any user's next call wakes it; and use cancels a pending power-down — a
+`ready` environment whose desired power was lowered by the reaper is written
+back to `running` when a call resolves it, before the reconciler can freeze
+it under that call. Such an environment is closed only by an operator or by
+its own idle policy, never by a session or a bot.
+
 ## Power states and idle policy
 
 A provisioned environment carries a Lightspeed-owned power intent,

--- a/platform/bots/src/activities/control-plane.ts
+++ b/platform/bots/src/activities/control-plane.ts
@@ -1,4 +1,5 @@
-import type { Db } from "@lightspeed/platform-db";
+import { eq } from "drizzle-orm";
+import { schema, type Db } from "@lightspeed/platform-db";
 import type { BotEventFinalOutcome } from "../contracts/bots.js";
 import { recordEventOutcomes } from "../admission.js";
 
@@ -11,9 +12,21 @@ export interface RecordEventOutcomesInput {
   runId: string | null;
 }
 
+export interface RecordBotClosedInput {
+  botId: string;
+  /** Every session the controller closed on the way out, main generations first. */
+  sessions: string[];
+}
+
 export interface BotControlPlaneActivities {
   /** Write-once outcome on every event row of a finished delivery. */
   recordEventOutcomes(input: RecordEventOutcomesInput): Promise<{ updated: number }>;
+  /**
+   * The controller's last write before it completes: the sessions it closed,
+   * so delete can erase them once the workflow is gone. Union with what an
+   * earlier teardown attempt recorded — a retried close must not lose ids.
+   */
+  recordBotClosed(input: RecordBotClosedInput): Promise<{ sessions: string[] }>;
 }
 
 export function createBotControlPlaneActivities(db: Db): BotControlPlaneActivities {
@@ -25,6 +38,20 @@ export function createBotControlPlaneActivities(db: Db): BotControlPlaneActiviti
         deliveryId: input.deliveryId,
         runId: input.runId,
       });
+    },
+
+    async recordBotClosed(input) {
+      const [existing] = await db
+        .select({ closedSessions: schema.bots.closedSessions })
+        .from(schema.bots)
+        .where(eq(schema.bots.id, input.botId))
+        .limit(1);
+      const sessions = [...new Set([...(existing?.closedSessions ?? []), ...input.sessions])];
+      await db
+        .update(schema.bots)
+        .set({ closedSessions: sessions })
+        .where(eq(schema.bots.id, input.botId));
+      return { sessions };
     },
   };
 }

--- a/platform/bots/src/activities/lightspeed.ts
+++ b/platform/bots/src/activities/lightspeed.ts
@@ -140,11 +140,14 @@ export interface BotLightspeedActivities {
   steerBotRun(input: SteerBotRunInput): Promise<{ steered: boolean; runId?: string }>;
   appendBotContext(input: AppendBotContextInput): Promise<void>;
   /**
-   * Close an idle managed session (non-force: a busy session is left alone)
-   * together with its open sub-agent descendants (P134 lineage). A busy
-   * descendant blocks the close; the sweep retries later.
+   * Close a managed session together with its open sub-agent descendants
+   * (P134 lineage). Non-force (the default) leaves a busy session alone and
+   * the sweep retries later; `force` cancels the active run and drops queued
+   * ones — what a bot close does, matching `session/delete`.
    */
-  closeBotSession(input: ReadSessionInput): Promise<{ closed: boolean; descendantsClosed?: number }>;
+  closeBotSession(
+    input: ReadSessionInput & { force?: boolean },
+  ): Promise<{ closed: boolean; descendantsClosed?: number }>;
   /**
    * Sub-agent sessions delegated under the bot's sessions since `sinceMs`
    * (P134 lineage). Every descendant counts against the bot's daily run
@@ -159,6 +162,18 @@ export interface BotLightspeedActivities {
 
 /** Bound on lineage pages read per root when counting descendants. */
 const DESCENDANT_COUNT_MAX_PAGES = 10;
+
+async function isSessionClosed(
+  client: Pick<LightspeedClient, "call">,
+  sessionId: string,
+): Promise<boolean> {
+  try {
+    const read = await client.call("session/read", { sessionId });
+    return read.result.session.status === "closed";
+  } catch {
+    return false;
+  }
+}
 
 export function isBotSessionDeclarationMismatch(error: unknown): boolean {
   return (
@@ -288,10 +303,11 @@ export function createBotLightspeedActivities(
         rootSessionId: input.sessionId,
         limit: 200,
       });
+      const force = input.force === true;
       for (const child of descendants.result.sessions ?? []) {
         if (child.lifecycleStatus === "closed") continue;
         try {
-          await client.call("session/close", { sessionId: child.id });
+          await client.call("session/close", { sessionId: child.id, force });
           descendantsClosed += 1;
         } catch (error) {
           if (error instanceof LightspeedRpcError) return { closed: false, descendantsClosed };
@@ -299,11 +315,17 @@ export function createBotLightspeedActivities(
         }
       }
       try {
-        await client.call("session/close", { sessionId: input.sessionId });
+        await client.call("session/close", { sessionId: input.sessionId, force });
       } catch (error) {
         // Active work or an already-closed session: report and let the
-        // retention sweep try again later.
-        if (error instanceof LightspeedRpcError) return { closed: false, descendantsClosed };
+        // retention sweep try again later. A forced close treats an
+        // already-closed session as done — teardown must converge.
+        if (error instanceof LightspeedRpcError) {
+          if (force && (await isSessionClosed(client, input.sessionId))) {
+            return { closed: true, descendantsClosed };
+          }
+          return { closed: false, descendantsClosed };
+        }
         throw error;
       }
       return { closed: true, descendantsClosed };

--- a/platform/bots/src/activities/poll.ts
+++ b/platform/bots/src/activities/poll.ts
@@ -68,10 +68,37 @@ interface PollSpecRow {
         auth?: { grantId: string; header?: string; scheme?: string; audience?: string };
         body?: string;
       }
-    | { kind: "exec"; environmentId: string; argv: string[]; cwd?: string | null; timeoutMs?: number | null };
+    | {
+        kind: "exec";
+        /** Null: the bot's own environment (the profile's `existing` one), resolved at fire time. */
+        environmentId?: string | null;
+        argv: string[];
+        cwd?: string | null;
+        timeoutMs?: number | null;
+      };
   intervalMs: number;
   items: string | null;
   cursor: { kind: "idSet"; id: string } | { kind: "watermark"; field: string };
+}
+
+/**
+ * The environment an exec poll without an explicit `environmentId` runs in:
+ * the `existing` environment of the bot's profile. A profile with another
+ * intent (none, per-session provision, inherit) cannot run such a poll —
+ * that is a configuration error, not a transient failure.
+ */
+export async function resolveBotProfileEnvironment(
+  client: Pick<LightspeedClient, "call">,
+  profileId: string,
+): Promise<string> {
+  const profile = (await client.call("profiles/read", { profileId })).result.profile;
+  const environment = profile.environment;
+  if (environment?.type !== "existing") {
+    throw new Error(
+      `the poll names no environment and profile ${profileId} does not activate an existing one: set environmentId on the trigger, or point the profile at an existing environment`,
+    );
+  }
+  return environment.environmentId;
 }
 
 type PollHttpSource = Extract<PollSpecRow["source"], { kind: "http" }>;
@@ -172,12 +199,15 @@ export function createBotPollActivities(config: BotPollActivitiesConfig): BotPol
     triggerId: string,
     scheduledAt: string,
     source: Extract<PollSpecRow["source"], { kind: "exec" }>,
+    profileId: string,
   ): Promise<unknown> {
     const client = clientFor(universeId);
+    const environmentId =
+      source.environmentId ?? (await resolveBotProfileEnvironment(client, profileId));
     const budgetMs = source.timeoutMs ?? EXEC_DEFAULT_TIMEOUT_MS;
     const requestId = `poll-${digestHex(`${triggerId}:${scheduledAt}`).slice(0, 24)}`;
     const created = await client.call("environments/jobs/create", {
-      environmentId: source.environmentId,
+      environmentId,
       requestId,
       jobs: [
         {
@@ -190,7 +220,7 @@ export function createBotPollActivities(config: BotPollActivitiesConfig): BotPol
     });
     const started = created.result.jobs?.[0];
     if (!started) throw new Error("environment job start returned no job");
-    const handle = { environmentId: source.environmentId, jobId: started.jobId };
+    const handle = { environmentId, jobId: started.jobId };
     const deadline = Date.now() + budgetMs + 30_000;
     let afterSeq: number | undefined;
     let stdout = "";
@@ -286,6 +316,7 @@ export function createBotPollActivities(config: BotPollActivitiesConfig): BotPol
                 row.trigger.id,
                 input.scheduledAt,
                 spec.source,
+                row.bot.profileId,
               );
       } catch (error) {
         // A sleeping environment is not a failure: the resolver has begun

--- a/platform/bots/src/activities/tools.ts
+++ b/platform/bots/src/activities/tools.ts
@@ -681,14 +681,19 @@ export function parseTriggerPutArgs(args: Record<string, unknown>): {
             }),
       };
     } else {
-      if (environmentId === null || argv === null || argv.length === 0) {
+      if (argv === null || argv.length === 0) {
         throw new BotConfigError(
-          "a poll source needs url (http) or environmentId plus argv (exec)",
+          "a poll source needs url (http) or argv (exec; environmentId defaults to the bot's own environment)",
           400,
         );
       }
       const cwd = nullableString(args.cwd);
-      source = { kind: "exec", environmentId, argv, ...(cwd === null ? {} : { cwd }) };
+      source = {
+        kind: "exec",
+        ...(environmentId === null ? {} : { environmentId }),
+        argv,
+        ...(cwd === null ? {} : { cwd }),
+      };
     }
     const spec = {
       source,

--- a/platform/bots/src/admission.ts
+++ b/platform/bots/src/admission.ts
@@ -63,6 +63,8 @@ export interface AdmissionDeps {
 export const BOT_REFUSAL_CODES = [
   "unknown_bot",
   "bot_disabled",
+  /** Terminal, unlike `bot_disabled`: the target was closed and will not come back. */
+  "bot_closed",
   "no_inbox",
   "not_accepted",
   "filtered",
@@ -98,6 +100,7 @@ export function botStartFor(bot: BotRow, universeId: string): BotStartV1 {
     selfConfig: bot.selfConfig,
     emit: bot.emit,
     enabled: bot.enabled,
+    ...(bot.closedAt === null ? {} : { closed: true }),
   };
 }
 
@@ -137,14 +140,16 @@ export function deliveryHops(events: Pick<BotEvent, "hops">[]): number {
 }
 
 export interface InboxTarget {
-  bot: Pick<BotRow, "name" | "enabled">;
+  bot: Pick<BotRow, "name" | "enabled" | "closedAt">;
   /** The target's `bot`-kind trigger, if any. */
   inbox: BotTriggerRow | null;
 }
 
 /**
  * Resolve the inbox an addressed emit goes through: the target must exist,
- * be enabled, declare an enabled inbox, and list the sender (or nobody).
+ * be open and enabled, declare an enabled inbox, and list the sender (or
+ * nobody). A closed bot is refused with its own code so a sending model
+ * stops retrying.
  */
 export function resolveInbox(
   sender: Pick<BotRow, "name">,
@@ -153,6 +158,9 @@ export function resolveInbox(
 ): BotTriggerRow {
   if (target === null) {
     throw new BotAdmissionRefusal("unknown_bot", `no bot named ${targetName} in this universe`);
+  }
+  if (target.bot.closedAt !== null) {
+    throw new BotAdmissionRefusal("bot_closed", `${targetName} was closed and no longer accepts events`);
   }
   if (!target.bot.enabled) {
     throw new BotAdmissionRefusal("bot_disabled", `${targetName} is disabled`);
@@ -299,6 +307,15 @@ export async function storeBotEvent(
   deps: AdmissionDeps,
   input: StoreBotEventInput,
 ): Promise<{ event: BotEvent; duplicate: boolean }> {
+  // The resurrection guard: waking is a signal-with-start, so a closed bot
+  // must be refused on its row before anything is stored — otherwise a late
+  // event would start a fresh controller for a bot that no longer exists.
+  if (input.bot.closedAt !== null) {
+    throw new BotAdmissionRefusal(
+      "bot_closed",
+      `${input.bot.name} was closed and no longer accepts events`,
+    );
+  }
   const seq = await allocateBotEventSeq(deps.db, input.bot.id);
   const prompt = renderAdmittedEvent(seq, input.document, input.promptData);
   const promptBlob = { bytesBase64: Buffer.from(prompt, "utf8").toString("base64") };

--- a/platform/bots/src/config.ts
+++ b/platform/bots/src/config.ts
@@ -121,7 +121,8 @@ export const pollSourceInput = z.discriminatedUnion("kind", [
   pollHttpSourceInput,
   z.object({
     kind: z.literal("exec"),
-    environmentId: z.string().trim().min(1).max(300),
+    /** Absent: the bot's own environment (the profile's `existing` one), resolved at fire time. */
+    environmentId: z.string().trim().min(1).max(300).nullish(),
     argv: z.array(z.string().min(1).max(10_000)).min(1).max(64),
     cwd: z.string().trim().min(1).max(2_000).nullish(),
     timeoutMs: z.number().int().min(1_000).max(600_000).nullish(),
@@ -342,7 +343,7 @@ type PollSpecRow = {
         auth?: { grantId: string; header?: string; scheme?: string; audience?: string };
         body?: string;
       }
-    | { kind: "exec"; environmentId: string; argv: string[]; cwd?: string | null; timeoutMs?: number | null };
+    | { kind: "exec"; environmentId: string | null; argv: string[]; cwd?: string | null; timeoutMs?: number | null };
   intervalMs: number;
   items: string | null;
   cursor: { kind: "idSet"; id: string } | { kind: "watermark"; field: string };
@@ -370,7 +371,7 @@ function normalizePollSpec(spec: z.infer<typeof pollSpecInput>): PollSpecRow {
         }
       : {
           kind: "exec" as const,
-          environmentId: spec.source.environmentId,
+          environmentId: spec.source.environmentId ?? null,
           argv: spec.source.argv,
           cwd: spec.source.cwd ?? null,
           timeoutMs: spec.source.timeoutMs ?? null,

--- a/platform/bots/src/contracts/bots.ts
+++ b/platform/bots/src/contracts/bots.ts
@@ -72,6 +72,13 @@ export interface BotStartV1 {
   /** Capability grant: declare `bot_emit` (events to itself or to another bot's inbox). */
   emit?: boolean;
   enabled: boolean;
+  /**
+   * Terminal teardown: the controller archives what is pending, closes every
+   * session (force), records the closed sessions on the row, and completes
+   * instead of continuing as new. Idempotent — a fresh run started with
+   * `closed` tears down again.
+   */
+  closed?: boolean;
 }
 
 /** Operator request to close one managed session and advance its generation. */
@@ -494,7 +501,7 @@ export const BOT_TOOL_DESCRIPTIONS = {
   status:
     "Inspect this bot's state: enabled flag, run budget, sessions, coalescing buffers, active and recent deliveries.",
   triggerPut:
-    "Create or update one of this bot's triggers by name. kind=schedule needs cron (5-field) or at (one-shot ISO instant) plus summary; kind=webhook returns an ingest URL to give to the sender; kind=poll checks a source every intervalMs and delivers only new items (cursorId for id-based dedupe, or watermarkField for ordered feeds). The poll source is url (HTTP JSON) or environmentId+argv (run a command in that environment; its stdout must be JSON). kind=bot is this bot's inbox for events other bots address to it (at most one; from lists the bot ids allowed, omit for any). kind=chat connects a messaging account (channelAccount from bot_trigger_list or the operator, e.g. telegram:mybot): every message becomes an event in a session per conversation with message_send/edit/react tools; the returned pairingCode must be sent in the chat once to pair it. Filters and route keys are CEL over event, data, headers.",
+    "Create or update one of this bot's triggers by name. kind=schedule needs cron (5-field) or at (one-shot ISO instant) plus summary; kind=webhook returns an ingest URL to give to the sender; kind=poll checks a source every intervalMs and delivers only new items (cursorId for id-based dedupe, or watermarkField for ordered feeds). The poll source is url (HTTP JSON) or argv (run a command in environmentId, or in this bot's own environment when omitted; its stdout must be JSON). kind=bot is this bot's inbox for events other bots address to it (at most one; from lists the bot ids allowed, omit for any). kind=chat connects a messaging account (channelAccount from bot_trigger_list or the operator, e.g. telegram:mybot): every message becomes an event in a session per conversation with message_send/edit/react tools; the returned pairingCode must be sent in the chat once to pair it. Filters and route keys are CEL over event, data, headers.",
   triggerDelete: "Delete one of this bot's triggers by name.",
   triggerList: "List this bot's configured triggers with their specs, filters, routing, and ingest URLs.",
   filterTest:
@@ -615,12 +622,12 @@ export const BOT_TOOL_SCHEMAS = {
       },
       environmentId: {
         type: ["string", "null"],
-        description: "Poll kind, exec source: environment the command runs in (woken on use); requires argv",
+        description: "Poll kind, exec source: environment the command runs in (woken on use); omit to run in this bot's own environment",
       },
       argv: {
         type: ["array", "null"],
         items: { type: "string" },
-        description: "Poll kind, exec source: command argv; stdout must be JSON (the item list, or use items)",
+        description: "Poll kind, exec source: command argv run in environmentId or, when omitted, this bot's own environment; stdout must be JSON (the item list, or use items)",
       },
       cwd: { type: ["string", "null"], description: "Poll kind, exec source: working directory" },
       intervalMs: {

--- a/platform/bots/src/workflows/bot-controller.ts
+++ b/platform/bots/src/workflows/bot-controller.ts
@@ -126,7 +126,10 @@ export interface BotSnapshot {
     | "session_busy"
     | "delivering_event"
     | "budget_exhausted"
-    | "degraded";
+    | "degraded"
+    /** Terminal teardown in progress / finished (the workflow completes right after). */
+    | "closing"
+    | "closed";
   activeDeliveries: BotActiveDeliverySnapshot[];
   sessionReady: boolean;
   pendingEventCount: number;
@@ -213,7 +216,7 @@ export const botStateQuery = defineQuery<BotSnapshot>(BOT_STATE_QUERY);
 export async function botControllerWorkflowV1(
   initial: BotStartV1,
   carry?: BotCarryV1,
-): Promise<never> {
+): Promise<void> {
   validateConfig(initial);
   let config = carry?.config ?? initial;
   const baseSessionId = botSessionId(config.botName);
@@ -282,6 +285,13 @@ export async function botControllerWorkflowV1(
   let rotationRetryAtMs: number | null = null;
   let setupStatus: "initializing" | "degraded" | "ready" = "initializing";
   let configDirty = true;
+  // Terminal teardown (bot close): set once the closed config is seen; the
+  // workflow completes right after `teardown()` and never continues as new.
+  let closing = false;
+  let closedDone = false;
+  // Read through a function: `config` is replaced by the signal handler,
+  // which TypeScript's narrowing cannot see from the loop body.
+  const closeRequested = (): boolean => config.closed === true;
   // A display-name change is label-only; it renames sessions, never rotates them.
   let renameDirty = false;
   let lastError: string | null = null;
@@ -443,7 +453,7 @@ export async function botControllerWorkflowV1(
   }
 
   function dispatchable(): boolean {
-    if (!config.enabled || !sessionReady || configDirty) return false;
+    if (!config.enabled || closeRequested() || !sessionReady || configDirty) return false;
     if (pendingDeliveries.length === 0) return false;
     if (config.runsPerDay !== null && utcDay() === runDay && reservedRuns() >= config.runsPerDay) {
       return false;
@@ -526,14 +536,17 @@ export async function botControllerWorkflowV1(
     profileId: config.profileId,
     sessionId,
     sessions: [{ sessionId, label: "main", kind: "main" as const }, ...extraSessions],
-    controllerStatus:
-      setupStatus !== "ready"
-        ? setupStatus
-        : activeBySession.size > 0
-          ? "delivering_event"
-          : pendingDeliveries.length > 0 && budgetExhaustedView()
-            ? "budget_exhausted"
-            : "idle",
+    controllerStatus: closedDone
+      ? "closed"
+      : closing
+        ? "closing"
+        : setupStatus !== "ready"
+          ? setupStatus
+          : activeBySession.size > 0
+            ? "delivering_event"
+            : pendingDeliveries.length > 0 && budgetExhaustedView()
+              ? "budget_exhausted"
+              : "idle",
     activeDeliveries: [...activeBySession.values()].map((active) => ({
       id: active.delivery.id,
       eventCount: active.delivery.events.length,
@@ -984,10 +997,30 @@ export async function botControllerWorkflowV1(
           : { carriedToolIds: ensured.carriedToolIds }),
       });
       if (extraSessions.length > EXTRA_SESSION_CAP) {
+        // A session evicted from the tracked set would otherwise escape the
+        // retention sweep and any teardown: close it (non-force) as it
+        // leaves. A busy one stays tracked and is retried at the next sweep.
         const evicted = extraSessions.splice(0, extraSessions.length - EXTRA_SESSION_CAP);
         for (const session of evicted) {
+          let closed = false;
+          try {
+            closed = (
+              await activities.closeBotSession({
+                universeId: config.universeId,
+                sessionId: session.sessionId,
+              })
+            ).closed;
+          } catch (error) {
+            lastError = errorMessage(error);
+          }
+          if (!closed) {
+            extraSessions.unshift(session);
+            continue;
+          }
           ensuredExtra.delete(session.sessionId);
           sessionCursors.delete(session.sessionId);
+          const base = routedBase(session.sessionId);
+          sessionGenerations.set(base, (sessionGenerations.get(base) ?? 1) + 1);
         }
       }
       return sessionIdToEnsure;
@@ -1428,9 +1461,80 @@ export async function botControllerWorkflowV1(
     }
   }
 
+  /**
+   * Terminal teardown (bot close): archive everything not yet delivered,
+   * force-close every session this controller knows (main generations and
+   * routed sessions; descendants go first inside the activity), and record
+   * the closed sessions on the row so delete can erase them once this
+   * workflow is gone. The bot's environment is untouched: it is the
+   * profile's `existing` environment, a universe resource. Every step is
+   * an idempotent activity: a failed one is reported, not retried here — a
+   * fresh run started with `closed` repeats the whole procedure. Lanes still
+   * in flight lose their session underneath and settle on their own.
+   */
+  async function teardown(): Promise<void> {
+    closing = true;
+    const eventIds = [
+      ...new Set([
+        ...pendingDeliveries.flatMap((delivery) => delivery.events.map((event) => event.id)),
+        ...[...buffers.values()].flatMap((buffer) => buffer.events.map((event) => event.id)),
+        ...[...activeBySession.values()].flatMap((active) =>
+          active.delivery.events.map((event) => event.id),
+        ),
+      ]),
+    ];
+    if (eventIds.length > 0) {
+      try {
+        await activities.recordEventOutcomes({
+          botId: config.botId,
+          eventIds,
+          outcome: "archived",
+          detail: "bot_closed",
+          deliveryId: null,
+          runId: null,
+        });
+      } catch (error) {
+        lastError = errorMessage(error);
+      }
+    }
+    pendingDeliveries.length = 0;
+    buffers.clear();
+    const sessions = [
+      ...new Set([
+        ...Array.from({ length: mainGeneration }, (_, index) => mainSessionIdFor(index + 1)),
+        ...extraSessions.map((session) => session.sessionId),
+      ]),
+    ];
+    for (const target of sessions) {
+      try {
+        await activities.closeBotSession({
+          universeId: config.universeId,
+          sessionId: target,
+          force: true,
+        });
+      } catch (error) {
+        lastError = errorMessage(error);
+      }
+    }
+    try {
+      await activities.recordBotClosed({ botId: config.botId, sessions });
+    } catch (error) {
+      lastError = errorMessage(error);
+    }
+    closedDone = true;
+  }
+
+  if (closeRequested()) {
+    await teardown();
+    return;
+  }
   await reconcileSession();
 
   for (;;) {
+    if (closeRequested()) {
+      await teardown();
+      return;
+    }
     await processEmissions();
     await rotateRequestedSessions();
     flushRipeBuffers();
@@ -1483,6 +1587,7 @@ export async function botControllerWorkflowV1(
     const tick = laneTick;
     const observedEventTick = eventTick;
     const wake = () =>
+      closeRequested() ||
       emissionInbox.length > 0 ||
       (configDirty && !activeBySession.has(sessionId) && !sidecarBySession.has(sessionId)) ||
       laneTick !== tick ||

--- a/platform/bots/test/admission.test.ts
+++ b/platform/bots/test/admission.test.ts
@@ -45,7 +45,7 @@ function inbox(overrides: Partial<BotTriggerRow> = {}): BotTriggerRow {
 }
 
 function target(overrides: Partial<InboxTarget> = {}): InboxTarget {
-  return { bot: { name: "infra", enabled: true }, inbox: inbox(), ...overrides };
+  return { bot: { name: "infra", enabled: true, closedAt: null }, inbox: inbox(), ...overrides };
 }
 
 function refusalCode(fn: () => unknown): string | null {
@@ -70,7 +70,21 @@ describe("addressed emit admission", () => {
 
   it("refuses with a typed code for every admission failure", () => {
     expect(refusalCode(() => resolveInbox(sender, "ghost", null))).toBe("unknown_bot");
-    expect(refusalCode(() => resolveInbox(sender, "infra", target({ bot: { name: "infra", enabled: false } })))).toBe(
+    // Closed is terminal and wins over disabled: a sender should stop, not retry.
+    expect(
+      refusalCode(() =>
+        resolveInbox(
+          sender,
+          "infra",
+          target({ bot: { name: "infra", enabled: false, closedAt: new Date("2026-08-27T09:00:00Z") } }),
+        ),
+      ),
+    ).toBe("bot_closed");
+    expect(
+      refusalCode(() =>
+        resolveInbox(sender, "infra", target({ bot: { name: "infra", enabled: false, closedAt: null } })),
+      ),
+    ).toBe(
       "bot_disabled",
     );
     expect(refusalCode(() => resolveInbox(sender, "infra", target({ inbox: null })))).toBe("no_inbox");

--- a/platform/bots/test/bots.integration.test.ts
+++ b/platform/bots/test/bots.integration.test.ts
@@ -1467,6 +1467,124 @@ describe.runIf(runIntegration)("bot controller workflow", () => {
     }
   }, 60_000);
 
+  it("closes: archives pending events, force-closes sessions, records them, and completes", async () => {
+    const closingBotName = "closing";
+    const ensured: string[] = [];
+    const closedSessions: Array<{ sessionId: string; force?: boolean }> = [];
+    const outcomes: unknown[] = [];
+    const recorded: string[][] = [];
+    const workflowWorker = await Worker.create({
+      connection: env.nativeConnection,
+      namespace: env.namespace ?? "default",
+      taskQueue: BOTS_WORKFLOW_TASK_QUEUE,
+      workflowsPath: fileURLToPath(new URL("./workflows.ts", import.meta.url)),
+    });
+    const activityWorker = await Worker.create({
+      connection: env.nativeConnection,
+      namespace: env.namespace ?? "default",
+      taskQueue: BOTS_ACTIVITY_TASK_QUEUE,
+      activities: {
+        ...defaultUsageActivities,
+        ensureBotSession: async ({ sessionId }: { sessionId: string }) => {
+          ensured.push(sessionId);
+          return { profileRevision: 1 };
+        },
+        closeBotSession: async (input: { sessionId: string; force?: boolean }) => {
+          closedSessions.push({ sessionId: input.sessionId, ...(input.force === undefined ? {} : { force: input.force }) });
+          return { closed: true };
+        },
+        recordBotClosed: async ({ sessions }: { sessions: string[] }) => {
+          recorded.push(sessions);
+          return { sessions };
+        },
+        recordEventOutcomes: async (input: unknown) => {
+          outcomes.push(input);
+          return { updated: 1 };
+        },
+      },
+    });
+    const workflowRun = workflowWorker.run();
+    const activityRun = activityWorker.run();
+
+    try {
+      // Disabled, so the event stays pending: close must archive it.
+      const start: BotStartV1 = {
+        version: 1,
+        universeId,
+        botId,
+        botName: closingBotName,
+        displayName: null,
+        profileId: "triage-bot",
+        brief: null,
+        runsPerDay: null,
+        enabled: false,
+      };
+      const event: BotEvent = {
+        version: 1,
+        id: "delivery-close-1",
+        ref: eventRef,
+        seq: 3,
+        promptRef: `sha256:${"e".repeat(64)}`,
+      };
+      const workflowId = botWorkflowId(universeId, closingBotName);
+      const handle = await env.client.workflow.signalWithStart(BOT_CONTROLLER_WORKFLOW, {
+        workflowId,
+        taskQueue: BOTS_WORKFLOW_TASK_QUEUE,
+        args: [start],
+        signal: BOT_EVENT_SIGNAL,
+        signalArgs: [event],
+      });
+      const base = botSessionId(closingBotName);
+      await eventually(
+        () => handle.query<BotSnapshot>(BOT_STATE_QUERY),
+        (state) => state.sessionReady && state.pendingEventCount === 1,
+      );
+
+      await handle.signal(BOT_CONFIG_SIGNAL, { ...start, closed: true });
+      // The controller completes instead of continuing as new.
+      await handle.result();
+      expect((await handle.describe()).status.name).toBe("COMPLETED");
+
+      expect(outcomes).toEqual([
+        expect.objectContaining({
+          botId,
+          eventIds: [event.id],
+          outcome: "archived",
+          detail: "bot_closed",
+        }),
+      ]);
+      expect(closedSessions).toEqual([{ sessionId: base, force: true }]);
+      expect(recorded).toEqual([[base]]);
+      expect(ensured).toEqual([base]);
+
+      const history = await handle.fetchHistory();
+      await Worker.runReplayHistory(
+        { workflowsPath: fileURLToPath(new URL("./workflows.ts", import.meta.url)) },
+        history,
+        workflowId,
+      );
+
+      // A retried close (signal-with-start on the completed workflow) starts
+      // a fresh run that tears down again — idempotently — and completes
+      // without ever creating a session.
+      const again = await env.client.workflow.signalWithStart(BOT_CONTROLLER_WORKFLOW, {
+        workflowId,
+        taskQueue: BOTS_WORKFLOW_TASK_QUEUE,
+        args: [{ ...start, closed: true }],
+        signal: BOT_CONFIG_SIGNAL,
+        signalArgs: [{ ...start, closed: true }],
+      });
+      await again.result();
+      expect(ensured).toEqual([base]);
+      expect(recorded).toEqual([[base], [base]]);
+      expect(closedSessions).toHaveLength(2);
+    } finally {
+      workflowWorker.shutdown();
+      activityWorker.shutdown();
+      await Promise.all([workflowRun, activityRun]);
+    }
+  }, 60_000);
+
   it("reconciles schedules and fires them through the admission activity", async () => {
     const admissions: unknown[] = [];
     const polls: unknown[] = [];

--- a/platform/bots/test/tool-views.test.ts
+++ b/platform/bots/test/tool-views.test.ts
@@ -39,6 +39,8 @@ const bot: BotRow = {
   selfConfig: true,
   emit: true,
   enabled: true,
+  closedAt: null,
+  closedSessions: null,
   createdAt: new Date("2026-08-26T10:00:00Z"),
   updatedAt: new Date("2026-08-26T10:00:00Z"),
 };

--- a/platform/bots/test/tools.test.ts
+++ b/platform/bots/test/tools.test.ts
@@ -322,6 +322,22 @@ describe("poll trigger mapping and validation", () => {
     expect(() =>
       parseTriggerPutArgs({ name: "x", kind: "poll", environmentId: "environment_1", intervalMs: 60_000, cursorId: "id" }),
     ).toThrow(/needs url/);
+    // No environmentId: the poll runs in the bot's own environment (the
+    // profile's existing one), resolved when the trigger fires.
+    const scoped = parseTriggerPutArgs({
+      name: "own-box",
+      kind: "poll",
+      argv: ["./check.sh"],
+      intervalMs: 60_000,
+      cursorId: "id",
+    });
+    expect(triggerCreateInput.parse(scoped.create)).toMatchObject({
+      kind: "poll",
+      spec: { source: { kind: "exec", argv: ["./check.sh"] } },
+    });
+    expect(
+      (triggerCreateInput.parse(scoped.create).spec as { source: Record<string, unknown> }).source,
+    ).not.toHaveProperty("environmentId", expect.any(String));
   });
 
   it("requires exactly one dedupe discipline and a sane interval", () => {

--- a/platform/db/migrations/0002_bots.sql
+++ b/platform/db/migrations/0002_bots.sql
@@ -13,6 +13,8 @@ CREATE TABLE "bots" (
 	"self_config" boolean DEFAULT false NOT NULL,
 	"emit" boolean DEFAULT false NOT NULL,
 	"enabled" boolean DEFAULT true NOT NULL,
+	"closed_at" timestamp with time zone,
+	"closed_sessions" jsonb,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
 );

--- a/platform/db/migrations/meta/0002_snapshot.json
+++ b/platform/db/migrations/meta/0002_snapshot.json
@@ -1734,6 +1734,18 @@
           "notNull": true,
           "default": true
         },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_sessions": {
+          "name": "closed_sessions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
         "created_at": {
           "name": "created_at",
           "type": "timestamp with time zone",

--- a/platform/db/scripts/check-migrations.ts
+++ b/platform/db/scripts/check-migrations.ts
@@ -77,6 +77,8 @@ async function checkEmptyInstall(connectionString: string): Promise<void> {
     await requireTable(handle.pool, "bot_events");
     await requireColumn(handle.pool, "bots", "emit");
     await requireColumn(handle.pool, "bots", "display_name");
+    await requireColumn(handle.pool, "bots", "closed_at");
+    await requireColumn(handle.pool, "bots", "closed_sessions");
     await requireColumn(handle.pool, "bot_events", "sender_bot_id");
     await requireColumn(handle.pool, "bot_events", "notify");
     await requireColumn(handle.pool, "bot_triggers", "session_ttl_ms");

--- a/platform/db/src/schema/bots.ts
+++ b/platform/db/src/schema/bots.ts
@@ -58,6 +58,19 @@ export const bots = pgTable(
      */
     emit: boolean("emit").default(false).notNull(),
     enabled: boolean("enabled").default(true).notNull(),
+    /**
+     * Terminal: set once by `close`, never cleared. A closed bot keeps its
+     * record and history but has released every live resource (sessions,
+     * schedules) and refuses new events; `enabled` cannot be turned back
+     * on. Delete erases it.
+     */
+    closedAt: timestamp("closed_at", { withTimezone: true }),
+    /**
+     * The sessions the controller closed on the way out, recorded by the
+     * controller itself (the authority on generations) so delete can erase
+     * them after the workflow is gone.
+     */
+    closedSessions: jsonb("closed_sessions").$type<string[]>(),
     createdAt: createdAt(),
     updatedAt: updatedAt(),
   },
@@ -88,7 +101,14 @@ export type BotPollTriggerSpec = {
         auth?: { grantId: string; header?: string; scheme?: string; audience?: string };
         body?: string;
       }
-    | { kind: "exec"; environmentId: string; argv: string[]; cwd?: string | null; timeoutMs?: number | null };
+    | {
+        kind: "exec";
+        /** Null runs in the bot's own environment (the profile's `existing` one, resolved at fire time). */
+        environmentId?: string | null;
+        argv: string[];
+        cwd?: string | null;
+        timeoutMs?: number | null;
+      };
   intervalMs: number;
   items?: string | null;
   cursor: { kind: "idSet"; id: string } | { kind: "watermark"; field: string };

--- a/platform/server/src/routes/bot-hooks.ts
+++ b/platform/server/src/routes/bot-hooks.ts
@@ -83,6 +83,10 @@ export function botHookRoutes(ctx: AppContext) {
       if (verified.reason === "unknown endpoint") return c.json({ error: "not found" }, 404);
       return c.json({ error: "verification failed", failure: verified.reason }, 401);
     }
+    // A closed bot is gone for good: tell the sender to stop, not to retry.
+    if (row.bot.closedAt !== null) {
+      return c.json({ error: "bot is closed" }, 410);
+    }
     if (!row.bot.enabled || !row.trigger.enabled) {
       return c.json({ error: "trigger is disabled" }, 409);
     }

--- a/platform/server/src/routes/bots.ts
+++ b/platform/server/src/routes/bots.ts
@@ -1,6 +1,7 @@
 import { Hono, type Context } from "hono";
-import { and, count, desc, eq, getTableColumns, inArray, lt, or } from "drizzle-orm";
+import { and, count, desc, eq, getTableColumns, inArray, isNull, lt, or } from "drizzle-orm";
 import { z } from "zod";
+import { LightspeedRpcError } from "@lightspeed/agent-client";
 import { schema } from "@lightspeed/platform-db";
 import {
   BOT_SESSION_ROTATE_SIGNAL,
@@ -94,6 +95,8 @@ const historyCursorSchema = z.object({
 });
 const DEFAULT_HISTORY_LIMIT = 50;
 const MAX_HISTORY_LIMIT = 100;
+/** How long a close waits for the controller's teardown before answering `completed: false`. */
+const BOT_CLOSE_WAIT_MS = 30_000;
 const BOT_LIST_COLLATOR = new Intl.Collator("en", { sensitivity: "base", numeric: true });
 
 type BotContext = Context<{ Variables: ApiVariables }>;
@@ -262,11 +265,135 @@ export function botRoutes(ctx: AppContext) {
     return c.json({ bot: botView(found.bot) });
   });
 
+  /**
+   * Terminal close. The row is marked first so every later step is
+   * retry-safe and admission refuses from here on; then triggers are
+   * disabled (`bot_closed`, schedules paused), and the controller is told to
+   * tear down — archive what is pending, force-close its sessions, record
+   * the closed sessions — and complete. The route waits a bounded time for
+   * that completion; `completed: false` means the teardown is still running
+   * (or the controller is unreachable) and a repeated close re-signals it.
+   * The bot's environment is untouched: it is a universe resource.
+   */
+  byUniverse.post("/:id/bots/:botId/close", async (c) => {
+    const found = await botForUniverse(c, true);
+    if (!found) return c.json({ error: "not found" }, 404);
+    const result = await closeBot(found.bot, found.access.universe.lightspeedUniverseId);
+    return c.json({ bot: botView(result.bot), completed: result.completed });
+  });
+
+  /**
+   * Erase. An open bot is closed first (and its teardown awaited); then the
+   * sessions the controller recorded are deleted from the core, every
+   * schedule is dropped, and the row goes (triggers, events, and pairings
+   * cascade), which frees the name. Environments are universe resources and
+   * stay.
+   */
+  byUniverse.delete("/:id/bots/:botId", async (c) => {
+    const found = await botForUniverse(c, true);
+    if (!found) return c.json({ error: "not found" }, 404);
+    const universeId = found.access.universe.lightspeedUniverseId;
+    const closed = await closeBot(found.bot, universeId);
+    if (!closed.completed) {
+      return c.json(
+        { error: "the bot's controller has not finished closing; retry the delete shortly" },
+        409,
+      );
+    }
+    const engine = engineClientFor(ctx, found.access.universe);
+    let sessionsDeleted = 0;
+    for (const sessionId of closed.bot.closedSessions ?? []) {
+      try {
+        await engine.call("session/delete", { sessionId });
+        sessionsDeleted += 1;
+      } catch (error) {
+        // Never created (a rotation that was never ensured) or already gone.
+        if (error instanceof LightspeedRpcError && error.kind === "not_found") continue;
+        return c.json(
+          { error: `failed to delete session ${sessionId}`, failure: errorMessage(error) },
+          502,
+        );
+      }
+    }
+    const temporal = await getTemporal();
+    const triggers = await ctx.db
+      .select()
+      .from(botTriggers)
+      .where(eq(botTriggers.botId, found.bot.id));
+    for (const trigger of triggers) {
+      try {
+        await deleteTrigger(triggerConfigDeps(found.access.universe, temporal), {
+          bot: closed.bot,
+          universeId,
+          existing: trigger,
+        });
+      } catch (error) {
+        return c.json(
+          { error: `failed to delete trigger ${trigger.name}`, failure: errorMessage(error) },
+          502,
+        );
+      }
+    }
+    await ctx.db.delete(bots).where(eq(bots.id, found.bot.id));
+    return c.json({ deleted: true, sessionsDeleted });
+  });
+
+  async function closeBot(
+    bot: BotRow,
+    universeId: string,
+  ): Promise<{ bot: BotRow; completed: boolean }> {
+    let current = bot;
+    if (current.closedAt === null) {
+      const [marked] = await ctx.db
+        .update(bots)
+        .set({ closedAt: new Date(), enabled: false })
+        .where(and(eq(bots.id, bot.id), isNull(bots.closedAt)))
+        .returning();
+      if (marked) current = marked;
+      else {
+        const [reread] = await ctx.db.select().from(bots).where(eq(bots.id, bot.id)).limit(1);
+        if (reread) current = reread;
+      }
+    }
+    await ctx.db
+      .update(botTriggers)
+      .set({ enabled: false, disabledReason: "bot_closed", disabledAt: new Date() })
+      .where(and(eq(botTriggers.botId, current.id), eq(botTriggers.enabled, true)));
+    await reconcileSchedules(current, universeId);
+    // The config carries `closed`; signal-with-start makes this restart-safe:
+    // a controller that already completed runs the teardown again and exits.
+    await signalBotConfig(botStart(current, universeId));
+    const temporal = await getTemporal();
+    const handle = temporal.workflow.getHandle(botWorkflowId(universeId, current.name));
+    const completed = await Promise.race([
+      handle.result().then(
+        () => true,
+        () => false,
+      ),
+      new Promise<boolean>((resolve) => {
+        setTimeout(() => resolve(false), BOT_CLOSE_WAIT_MS).unref();
+      }),
+    ]);
+    const [reread] = await ctx.db.select().from(bots).where(eq(bots.id, current.id)).limit(1);
+    return { bot: reread ?? current, completed };
+  }
+
   byUniverse.patch("/:id/bots/:botId", async (c) => {
     const found = await botForUniverse(c, true);
     if (!found) return c.json({ error: "not found" }, 404);
     const body = await parseBody(c, botUpdateSchema);
     if (!body.ok) return body.response;
+    if (found.bot.closedAt !== null) {
+      // A closed bot is history: labels may change, nothing that would bring
+      // it back or reconfigure a controller that no longer runs.
+      const labelsOnly = Object.keys(body.data).every(
+        (key) => key === "displayName" || key === "description",
+      );
+      if (!labelsOnly) return c.json({ error: "bot is closed" }, 409);
+      const [bot] = await ctx.db.update(bots).set(body.data).where(eq(bots.id, found.bot.id)).returning();
+      if (!bot) return c.json({ error: "not found" }, 404);
+      return c.json({ bot: botView(bot) });
+    }
     if (body.data.profileId !== undefined) {
       await engineClientFor(ctx, found.access.universe).call("profiles/read", {
         profileId: body.data.profileId,
@@ -452,6 +579,7 @@ export function botRoutes(ctx: AppContext) {
   byUniverse.post("/:id/bots/:botId/events", async (c) => {
     const found = await botForUniverse(c, true);
     if (!found) return c.json({ error: "not found" }, 404);
+    if (found.bot.closedAt !== null) return c.json({ error: "bot is closed" }, 410);
     if (!found.bot.enabled) return c.json({ error: "bot is disabled" }, 409);
     const body = await parseBody(c, eventCreateSchema);
     if (!body.ok) return body.response;

--- a/platform/web/src/api.ts
+++ b/platform/web/src/api.ts
@@ -561,6 +561,10 @@ export interface Bot {
   /** Whether this bot's sessions get bot_emit: events to itself or to other bots' inboxes (rate-capped). */
   emit: boolean;
   enabled: boolean;
+  /** Terminal: set by close; sessions and schedules are released, history stays. */
+  closedAt: string | null;
+  /** The sessions the controller closed on the way out; erased by delete. */
+  closedSessions: string[] | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -599,7 +603,14 @@ export type BotPollSource =
       auth?: { grantId: string; header?: string; scheme?: string; audience?: string };
       body?: string;
     }
-  | { kind: "exec"; environmentId: string; argv: string[]; cwd?: string | null; timeoutMs?: number | null };
+  | {
+      kind: "exec";
+      /** Absent: the bot's own environment (the profile's `existing` one), resolved when the poll fires. */
+      environmentId?: string | null;
+      argv: string[];
+      cwd?: string | null;
+      timeoutMs?: number | null;
+    };
 
 export interface BotPollSpec {
   source: BotPollSource;
@@ -673,7 +684,7 @@ export interface BotTrigger {
   cursor?: BotPollCursorState | null;
   enabled: boolean;
   /** Why the trigger is paused; null while enabled. */
-  disabledReason: "breaker" | "poll_failed" | "one_shot" | "operator" | null;
+  disabledReason: "breaker" | "poll_failed" | "one_shot" | "operator" | "bot_closed" | null;
   disabledAt: string | null;
   /** The filter's last evaluation error; it refuses events until the filter is fixed. */
   lastFilterError: string | null;
@@ -754,7 +765,9 @@ export interface BotState {
     | "session_busy"
     | "delivering_event"
     | "budget_exhausted"
-    | "degraded";
+    | "degraded"
+    | "closing"
+    | "closed";
   activeDeliveries: { id: string; eventCount: number; sessionId: string; runId: string | null }[];
   sessionReady: boolean;
   pendingEventCount: number;

--- a/platform/web/src/components/bot/detail.tsx
+++ b/platform/web/src/components/bot/detail.tsx
@@ -10,7 +10,7 @@ import {
   Settings2,
   Webhook,
 } from "lucide-react";
-import { Link, NavLink } from "react-router-dom";
+import { Link, NavLink, useNavigate } from "react-router-dom";
 import {
   api,
   botLabel,
@@ -37,9 +37,10 @@ import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { BotEnvironmentCard } from "./environment-card";
 import { BotSettingsDialog } from "./settings-dialog";
 import { SendEventDialog } from "./send-event-dialog";
-import { BotStatusBadge, KeyValue } from "./status";
+import { BotStatusBadge, DetailSection, KeyValue } from "./status";
 import { TriggersSection, type BotEnvStatus } from "./triggers";
 
 type BotView = "overview" | "events";
@@ -64,6 +65,7 @@ export function BotDetail({
   const [eventOpen, setEventOpen] = useState(false);
   const [view, setView] = useState<BotView>("overview");
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
   const eventPages = useInfiniteQuery({
     queryKey: ["bot-events", bot.universeId, bot.botId],
     queryFn: ({ pageParam }) =>
@@ -149,7 +151,13 @@ export function BotDetail({
       </div>
       {manage && (
         <>
-          <BotSettingsDialog universeId={bot.universeId} bot={bot} open={settingsOpen} onOpenChange={setSettingsOpen} />
+          <BotSettingsDialog
+            universeId={bot.universeId}
+            bot={bot}
+            open={settingsOpen}
+            onOpenChange={setSettingsOpen}
+            onDeleted={() => navigate(`/u/${slug}/bots`)}
+          />
           <SendEventDialog universeId={bot.universeId} botId={bot.botId} open={eventOpen} onOpenChange={setEventOpen} />
         </>
       )}
@@ -203,10 +211,18 @@ function BotOverview({
           <KeyValue label="Profile" value={bot.profileId} />
           <KeyValue label="Budget" value={budgetLabel(bot.runsPerDay, state)} />
           <KeyValue label="Processed" value={String(state?.eventsProcessed ?? 0)} />
-          {!bot.enabled && (
+          {bot.closedAt ? (
             <p className="rounded-md bg-muted p-2 text-xs text-muted-foreground">
-              Disabled: schedules are paused and pending events wait.
+              Closed {new Date(bot.closedAt).toLocaleString()}: sessions and schedules were
+              released and events are refused. The record and its history stay until the bot is
+              deleted.
             </p>
+          ) : (
+            !bot.enabled && (
+              <p className="rounded-md bg-muted p-2 text-xs text-muted-foreground">
+                Disabled: schedules are paused and pending events wait.
+              </p>
+            )
           )}
           {stateError && (
             <p className="rounded-md bg-destructive/10 p-2 text-xs text-destructive">
@@ -224,13 +240,22 @@ function BotOverview({
           )}
           {env.kind === "provision" && (
             <p className="rounded-md bg-amber-500/10 p-2 text-xs text-amber-700 dark:text-amber-400">
-              Profile <code>{bot.profileId}</code> provisions a fresh environment per session.
-              Command (exec) pollers need a stable environment id — a per-session machine closes
-              with its session and would strand the trigger. Point the profile at an existing
-              environment to author pollers.
+              Profile <code>{bot.profileId}</code> provisions a fresh environment per session
+              (a sandbox per event). Command (exec) pollers need a stable environment — a
+              per-session machine closes with its session and would strand the trigger. Point
+              the profile at an existing environment to author pollers.
             </p>
           )}
         </DetailSection>
+
+        {env.kind === "existing" && (
+          <BotEnvironmentCard
+            slug={slug}
+            universeId={bot.universeId}
+            environmentId={env.environmentId}
+            manage={manage}
+          />
+        )}
 
         <DetailSection title="Inbox now" description="Events waiting, coalescing, or actively delivering.">
           {state ? (
@@ -461,28 +486,6 @@ function EventHistory({
       {!loading && !error && events.length === 0 && <p className="text-xs text-muted-foreground">No events received yet.</p>}
       {hasMore && <LoadMoreButton loading={loadingMore} onClick={onLoadMore} />}
     </DetailSection>
-  );
-}
-
-function DetailSection({
-  title,
-  description,
-  children,
-}: {
-  title: string;
-  description?: string;
-  children: ReactNode;
-}) {
-  return (
-    <section className="grid min-w-0 content-start gap-3">
-      <div className="flex min-w-0 items-start justify-between gap-3">
-        <div className="grid min-w-0 flex-1 gap-0.5">
-          <h2 className="text-sm font-semibold">{title}</h2>
-          {description && <p className="text-xs text-muted-foreground">{description}</p>}
-        </div>
-      </div>
-      {children}
-    </section>
   );
 }
 

--- a/platform/web/src/components/bot/environment-card.tsx
+++ b/platform/web/src/components/bot/environment-card.tsx
@@ -1,0 +1,135 @@
+import { useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { ArrowUpRight } from "lucide-react";
+import { Link } from "react-router-dom";
+import { api, type Environment } from "@/api";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { EnvironmentIdlePolicyDialog } from "@/components/environment/idle-policy-dialog";
+import {
+  EnvironmentPowerControls,
+  describeIdlePolicy,
+  observedPower,
+  powerDiverges,
+} from "@/components/environment/power-controls";
+import { DetailSection, KeyValue } from "./status";
+
+const GONE = new Set(["closing", "closed", "failed"]);
+
+/**
+ * The environment a bot's sessions share: the `existing` environment its
+ * profile names. Status, power, and idle policy are shown next to the bot
+ * because that is where an operator looks when a bot seems asleep; the
+ * policy itself lives on the environment and is edited here or on the
+ * Environments page.
+ */
+export function BotEnvironmentCard({
+  slug,
+  universeId,
+  environmentId,
+  manage,
+}: {
+  /** Universe slug for page links. */
+  slug: string;
+  universeId: string;
+  environmentId: string;
+  manage: boolean;
+}) {
+  const queryClient = useQueryClient();
+  const [policyOpen, setPolicyOpen] = useState(false);
+  const environments = useQuery({
+    queryKey: ["environments", universeId],
+    queryFn: () => api<Environment[]>("GET", `/api/v1/universes/${universeId}/environments`),
+    refetchInterval: 15_000,
+  });
+  const refresh = () => {
+    void queryClient.invalidateQueries({ queryKey: ["environments", universeId] });
+  };
+  const current = environments.data?.find((environment) => environment.environmentId === environmentId);
+  const provisioned = current?.source.type === "provisioned";
+
+  return (
+    <DetailSection
+      title="Environment"
+      description="The existing environment this bot's profile activates in every session. Shared with anything else that names it."
+    >
+      {environments.isLoading ? (
+        <p className="text-xs text-muted-foreground">Loading…</p>
+      ) : environments.error ? (
+        <p className="rounded-md bg-destructive/10 p-2 text-xs text-destructive">{environments.error.message}</p>
+      ) : !current ? (
+        <p className="rounded-md bg-destructive/10 p-2 text-xs text-destructive">
+          Environment <code className="font-mono">{environmentId}</code> is not listed in this universe;
+          new sessions of this bot will fail to start until the profile points at an open one.
+        </p>
+      ) : (
+        <>
+          <KeyValue
+            label="Environment"
+            value={
+              <Link
+                to={`/u/${slug}/environments`}
+                className="inline-flex items-center gap-1 font-mono text-xs hover:underline"
+              >
+                {current.displayName ?? current.environmentId}
+                <ArrowUpRight className="size-3" />
+              </Link>
+            }
+          />
+          <KeyValue
+            label="Status"
+            value={
+              <span className="inline-flex items-center gap-2">
+                <Badge variant={GONE.has(current.status) ? "destructive" : current.status === "ready" ? "secondary" : "outline"}>
+                  {current.status}
+                </Badge>
+                {powerDiverges(current) && (
+                  <span className="text-xs text-muted-foreground">
+                    {observedPower(current) ?? current.status} → {current.desiredPower}
+                  </span>
+                )}
+              </span>
+            }
+          />
+          <KeyValue label="Idle policy" value={describeIdlePolicy(current.idlePolicy ?? undefined)} />
+          {manage && !GONE.has(current.status) && (
+            <div className="flex flex-wrap items-center gap-2">
+              <EnvironmentPowerControls universeId={universeId} environment={current} onChanged={refresh} />
+              {provisioned && (
+                <Button variant="outline" size="xs" onClick={() => setPolicyOpen(true)}>
+                  Idle policy…
+                </Button>
+              )}
+            </div>
+          )}
+          {GONE.has(current.status) && (
+            <p className="rounded-md bg-destructive/10 p-2 text-xs text-destructive">
+              This environment is {current.status}: new sessions of this bot cannot start until the
+              profile points at an open environment.
+            </p>
+          )}
+          {!GONE.has(current.status) && provisioned && !current.idlePolicy && (
+            <p className="rounded-md bg-amber-500/10 p-2 text-xs text-amber-700 dark:text-amber-400">
+              No idle policy: this environment never pauses, suspends, or stops while the bot is quiet.
+            </p>
+          )}
+          {!GONE.has(current.status) && !provisioned && (
+            <p className="rounded-md border border-dashed p-2 text-xs text-muted-foreground">
+              External environment: no power control, so it cannot be paused or stopped while idle.
+            </p>
+          )}
+          {manage && provisioned && (
+            <EnvironmentIdlePolicyDialog
+              key={`${current.environmentId}:${policyOpen ? "open" : "closed"}`}
+              universeId={universeId}
+              environment={current}
+              open={policyOpen}
+              onOpenChange={setPolicyOpen}
+              onChanged={refresh}
+            />
+          )}
+        </>
+      )}
+    </DetailSection>
+  );
+}

--- a/platform/web/src/components/bot/settings-dialog.tsx
+++ b/platform/web/src/components/bot/settings-dialog.tsx
@@ -1,6 +1,17 @@
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api, type Bot, type ProfileSummary } from "@/api";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -28,13 +39,47 @@ export function BotSettingsDialog({
   bot,
   open,
   onOpenChange,
+  onDeleted,
 }: {
   universeId: string;
   bot: Bot;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /** Called after a successful delete, once the record is gone. */
+  onDeleted?: () => void;
 }) {
   const queryClient = useQueryClient();
+  const closed = bot.closedAt !== null;
+  const refreshBot = async (updated: Bot | null) => {
+    if (updated) queryClient.setQueryData(["bot", universeId, bot.botId], { bot: updated });
+    await queryClient.invalidateQueries({ queryKey: ["bots", bot.universeId] });
+    await queryClient.invalidateQueries({ queryKey: ["bot-state", universeId, bot.botId] });
+  };
+  const close = useMutation({
+    mutationFn: () =>
+      api<{ bot: Bot; completed: boolean }>(
+        "POST",
+        `/api/v1/universes/${universeId}/bots/${bot.botId}/close`,
+      ),
+    onSuccess: async ({ bot: updated }) => {
+      await refreshBot(updated);
+      setError(null);
+      onOpenChange(false);
+    },
+    onError: (err) => setError(err.message),
+  });
+  const remove = useMutation({
+    mutationFn: () =>
+      api<{ deleted: boolean }>("DELETE", `/api/v1/universes/${universeId}/bots/${bot.botId}`),
+    onSuccess: async () => {
+      queryClient.removeQueries({ queryKey: ["bot", universeId, bot.botId] });
+      await queryClient.invalidateQueries({ queryKey: ["bots", bot.universeId] });
+      setError(null);
+      onOpenChange(false);
+      onDeleted?.();
+    },
+    onError: (err) => setError(err.message),
+  });
   const profiles = useQuery({
     queryKey: ["profiles", universeId],
     queryFn: () => api<ProfileSummary[]>("GET", `/api/v1/universes/${universeId}/profiles`),
@@ -225,14 +270,81 @@ export function BotSettingsDialog({
             </Label>
             <Switch id="bot-settings-self-emit" checked={emit} onCheckedChange={setEmit} />
           </div>
-          <div className="flex items-center justify-between rounded-md border p-3">
-            <Label htmlFor="bot-settings-enabled" className="text-sm">
-              Enabled
-              <span className="block text-xs font-normal text-muted-foreground">
-                Disabling pauses all schedules and stops event delivery.
-              </span>
-            </Label>
-            <Switch id="bot-settings-enabled" checked={enabled} onCheckedChange={setEnabled} />
+          {!closed && (
+            <div className="flex items-center justify-between rounded-md border p-3">
+              <Label htmlFor="bot-settings-enabled" className="text-sm">
+                Enabled
+                <span className="block text-xs font-normal text-muted-foreground">
+                  Disabling pauses all schedules and stops event delivery; sessions and their
+                  context stay, and the bot can be enabled again.
+                </span>
+              </Label>
+              <Switch id="bot-settings-enabled" checked={enabled} onCheckedChange={setEnabled} />
+            </div>
+          )}
+          <div className="grid gap-3 rounded-md border border-destructive/40 p-3">
+            <p className="text-sm font-medium">Lifecycle</p>
+            {closed ? (
+              <p className="text-xs text-muted-foreground">
+                Closed {new Date(bot.closedAt ?? "").toLocaleString()}. Sessions and schedules were
+                released and events are refused; the record and its history stay until the bot is
+                deleted.
+              </p>
+            ) : (
+              <div className="flex items-start justify-between gap-3">
+                <p className="text-xs text-muted-foreground">
+                  Closing is final: in-flight runs are cancelled, every session is closed,
+                  schedules are dropped, and new events are refused. The record, its event history,
+                  the bot id, and its environment stay.
+                </p>
+                <AlertDialog>
+                  <AlertDialogTrigger render={<Button variant="outline" size="sm" disabled={close.isPending} />}>
+                    {close.isPending ? "Closing…" : "Close bot"}
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>Close {bot.displayName ?? bot.botId}?</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        This cannot be undone. Pending events are archived, active runs are
+                        cancelled, all sessions are closed, and webhooks and other bots are
+                        refused from now on. The environment is left alone. To pause instead,
+                        turn the bot off.
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>Keep running</AlertDialogCancel>
+                      <AlertDialogAction onClick={() => close.mutate()}>Close bot</AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+              </div>
+            )}
+            <div className="flex items-start justify-between gap-3">
+              <p className="text-xs text-muted-foreground">
+                Deleting erases the bot, its triggers, its event history, and its sessions, and
+                frees the id{closed ? "." : " — it closes the bot first."} Environments are never
+                deleted with a bot.
+              </p>
+              <AlertDialog>
+                <AlertDialogTrigger render={<Button variant="destructive" size="sm" disabled={remove.isPending} />}>
+                  {remove.isPending ? "Deleting…" : "Delete bot"}
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>Delete {bot.displayName ?? bot.botId}?</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      {closed
+                        ? "The record, its event history, and its sessions are erased; the id becomes available again."
+                        : "The bot is closed first (runs cancelled, sessions closed, events refused), then the record, its event history, and its sessions are erased and the id becomes available again."}
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>Keep</AlertDialogCancel>
+                    <AlertDialogAction onClick={() => remove.mutate()}>Delete bot</AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+            </div>
           </div>
         </div>
         <div className="grid gap-2 border-t p-4">
@@ -241,7 +353,7 @@ export function BotSettingsDialog({
             <Button variant="outline" onClick={() => onOpenChange(false)}>
               Cancel
             </Button>
-            <Button onClick={() => save.mutate()} disabled={save.isPending || !profileId}>
+            <Button onClick={() => save.mutate()} disabled={save.isPending || !profileId || closed}>
               {save.isPending ? "Saving…" : "Save"}
             </Button>
           </DialogFooter>

--- a/platform/web/src/components/bot/status.tsx
+++ b/platform/web/src/components/bot/status.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import type { BotState } from "@/api";
 import { Badge } from "@/components/ui/badge";
 
@@ -9,7 +10,30 @@ export function BotStatusBadge({ status }: { status?: BotState["controllerStatus
   return <Badge variant="outline">{status.replaceAll("_", " ")}</Badge>;
 }
 
-export function KeyValue({ label, value }: { label: string; value: string }) {
+/** A titled block of the bot workspace. */
+export function DetailSection({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description?: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="grid min-w-0 content-start gap-3">
+      <div className="flex min-w-0 items-start justify-between gap-3">
+        <div className="grid min-w-0 flex-1 gap-0.5">
+          <h2 className="text-sm font-semibold">{title}</h2>
+          {description && <p className="text-xs text-muted-foreground">{description}</p>}
+        </div>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+export function KeyValue({ label, value }: { label: string; value: ReactNode }) {
   return (
     <div className="grid grid-cols-[5rem_minmax(0,1fr)] gap-2 text-xs">
       <span className="text-muted-foreground">{label}</span>

--- a/platform/web/src/components/bot/triggers.tsx
+++ b/platform/web/src/components/bot/triggers.tsx
@@ -117,6 +117,8 @@ function pausedLabel(reason: BotTrigger["disabledReason"]): string {
       return "paused: one-shot fired";
     case "operator":
       return "paused by operator";
+    case "bot_closed":
+      return "bot closed";
     default:
       return "paused";
   }
@@ -1033,7 +1035,7 @@ function pollFormFromTrigger(trigger: BotTrigger): PollFormState {
     authHeader: spec.source.kind === "http" ? (spec.source.auth?.header ?? "authorization") : "authorization",
     authScheme: spec.source.kind === "http" ? (spec.source.auth?.scheme ?? "Bearer") : "Bearer",
     authAudience: spec.source.kind === "http" ? (spec.source.auth?.audience ?? "") : "",
-    environmentId: spec.source.kind === "exec" ? spec.source.environmentId : "",
+    environmentId: spec.source.kind === "exec" ? (spec.source.environmentId ?? "") : "",
     argvText: spec.source.kind === "exec" ? spec.source.argv.join("\n") : "",
     cwd: spec.source.kind === "exec" ? (spec.source.cwd ?? "") : "",
     intervalMinutes: String(Math.round(spec.intervalMs / 60_000)),
@@ -1097,7 +1099,8 @@ function pollPayload(form: PollFormState) {
             }
           : {
               kind: "exec" as const,
-              environmentId: form.environmentId.trim(),
+              // Blank runs in the bot's own environment (the profile's existing one).
+              ...(form.environmentId.trim() ? { environmentId: form.environmentId.trim() } : {}),
               argv: pollArgv(form),
               ...(form.cwd.trim() ? { cwd: form.cwd.trim() } : {}),
             },
@@ -1112,11 +1115,17 @@ function pollPayload(form: PollFormState) {
   };
 }
 
-function pollFormProblem(form: PollFormState): string | null {
+/// `env` is the bot profile's environment intent when known: a blank
+/// environment is fine when the profile activates an existing one (the poll
+/// runs there), and left to the server otherwise.
+function pollFormProblem(form: PollFormState, env?: BotEnvStatus): string | null {
   if (form.sourceKind === "http") {
     if (!/^https?:\/\//.test(form.url.trim())) return "The poll URL must be http(s).";
   } else {
-    if (!form.environmentId.trim()) return "Name the environment the command runs in.";
+    const ownEnvironment = env === undefined || env.kind === "existing";
+    if (!form.environmentId.trim() && !ownEnvironment) {
+      return "Name the environment the command runs in.";
+    }
     if (pollArgv(form).length === 0) return "Give the command to run (one argv entry per line).";
   }
   const minutes = Number(form.intervalMinutes);
@@ -1507,12 +1516,13 @@ function PollFields({
               id="poll-environment"
               value={form.environmentId}
               onChange={(event) => setForm({ ...form, environmentId: event.target.value })}
-              placeholder="environment_…"
+              placeholder="Blank: the bot's own environment"
               className="font-mono"
             />
             <FieldDescription>
               The command runs as a one-shot job here with the environment's credentials; a
-              sleeping environment wakes for the poll and idles back down after.
+              sleeping environment wakes for the poll and idles back down after. Leave it blank
+              to run in the environment the bot's profile activates.
             </FieldDescription>
           </Field>
           <div className="grid grid-cols-[2fr_1fr] gap-3">
@@ -1635,7 +1645,7 @@ function AddTriggerDialog({
   const nameInvalid = name.trim().length > 0 && !NAME_PATTERN.test(name.trim());
   const cronIssue = kind === "schedule" && !once ? cronProblem(cron) : null;
   const webhookIssue = kind === "webhook" ? webhookFormProblem(webhook) : null;
-  const pollIssue = kind === "poll" ? pollFormProblem(poll) : null;
+  const pollIssue = kind === "poll" ? pollFormProblem(poll, env) : null;
   const inboxIssue = kind === "bot" ? inboxFormProblem(inbox) : null;
   const chatIssue = kind === "chat" ? chatFormProblem(chat) : null;
   const formIssue = webhookIssue ?? pollIssue ?? inboxIssue ?? chatIssue;

--- a/platform/web/src/components/environment/idle-policy-dialog.tsx
+++ b/platform/web/src/components/environment/idle-policy-dialog.tsx
@@ -1,0 +1,95 @@
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { api, type Environment } from "@/api";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { IdlePolicyFields, idlePolicyIsMonotone, type IdlePolicy } from "./idle-policy-fields";
+
+/**
+ * Edit (or clear) the idle policy of an existing provisioned environment
+ * (P126 `environments/idle-policy/put`). The policy lives on the environment,
+ * not on any profile or bot that uses it — this is the one place to set it
+ * for a box that long-lived sessions share.
+ */
+export function EnvironmentIdlePolicyDialog({
+  universeId,
+  environment,
+  open,
+  onOpenChange,
+  onChanged,
+}: {
+  universeId: string;
+  environment: Environment;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onChanged?: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const [policy, setPolicy] = useState<IdlePolicy | undefined>(environment.idlePolicy ?? undefined);
+  const [error, setError] = useState<string | null>(null);
+  const save = useMutation({
+    mutationFn: (next: IdlePolicy | undefined) =>
+      api<Environment>(
+        "PUT",
+        `/api/v1/universes/${universeId}/environments/${encodeURIComponent(environment.environmentId)}/idle-policy`,
+        { idlePolicy: next ?? null },
+      ),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["environments", universeId] });
+      onChanged?.();
+      setError(null);
+      onOpenChange(false);
+    },
+    onError: (err) => setError(err.message),
+  });
+  const label = environment.displayName ?? environment.environmentId;
+  const valid = idlePolicyIsMonotone(policy);
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Idle policy for {label}</DialogTitle>
+          <DialogDescription>
+            When nothing has used this environment for the given time — no session, bot, poller,
+            or shell — it is powered down stage by stage, and wakes on the next use. Leave every
+            stage empty to keep it running forever.
+          </DialogDescription>
+        </DialogHeader>
+        <IdlePolicyFields
+          value={policy}
+          warning={
+            policy === undefined
+              ? "No stages: this environment never pauses, suspends, or stops while idle."
+              : policy.closeAfterMs !== undefined && policy.closeAfterMs !== null
+                ? "A close stage destroys the environment; profiles and bots pointing at it will fail until they are repointed."
+                : undefined
+          }
+          onChange={setPolicy}
+        />
+        {error && <p className="text-sm text-destructive">{error}</p>}
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            variant="outline"
+            disabled={save.isPending || environment.idlePolicy == null}
+            onClick={() => save.mutate(undefined)}
+          >
+            Clear policy
+          </Button>
+          <Button disabled={save.isPending || !valid} onClick={() => save.mutate(policy)}>
+            {save.isPending ? "Saving…" : "Save"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/platform/web/src/components/environment/idle-policy-fields.tsx
+++ b/platform/web/src/components/environment/idle-policy-fields.tsx
@@ -1,0 +1,83 @@
+import type { EnvironmentIdlePolicyView } from "@lightspeed/agent-client";
+import { Field, FieldDescription, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+
+export type IdlePolicy = EnvironmentIdlePolicyView;
+
+export const IDLE_STAGES: Array<{ key: keyof IdlePolicy; label: string; hint: string }> = [
+  { key: "pauseAfterMs", label: "Pause after", hint: "Freeze execution; RAM stays resident, resume is instant." },
+  { key: "suspendAfterMs", label: "Suspend after", hint: "Save state to disk and free RAM (providers that support it)." },
+  { key: "stopAfterMs", label: "Stop after", hint: "Power off; disk is kept, resume is a fresh boot." },
+  { key: "closeAfterMs", label: "Close after", hint: "Destroy the environment. Not for a box a bot or several sessions rely on." },
+];
+
+/** True when every set stage is at or after the previous one (pause ≤ suspend ≤ stop ≤ close). */
+export function idlePolicyIsMonotone(value: IdlePolicy | undefined): boolean {
+  const ordered = IDLE_STAGES
+    .map((stage) => value?.[stage.key])
+    .filter((ms): ms is number => typeof ms === "number");
+  return ordered.every((ms, index) => index === 0 || ms >= (ordered[index - 1] ?? 0));
+}
+
+/// Idle policy (P126): minutes of daemon-reported idle time per stage. Empty
+/// stages are omitted; stages the provider cannot realize are skipped at
+/// runtime. A powered-down environment wakes when a session uses it. Shared
+/// by the profile editor (provisioned-per-session environments), the
+/// environment create dialog, and the per-environment idle-policy editor.
+export function IdlePolicyFields({
+  value,
+  warning,
+  onChange,
+}: {
+  value: IdlePolicy | undefined;
+  /// Shown instead of the default hint while the policy is valid.
+  warning?: string;
+  onChange: (policy: IdlePolicy | undefined) => void;
+}) {
+  const update = (key: keyof IdlePolicy, minutes: string) => {
+    const next: IdlePolicy = { ...(value ?? {}) };
+    const parsed = Number(minutes);
+    if (!minutes.trim() || !Number.isFinite(parsed) || parsed <= 0) {
+      delete next[key];
+    } else {
+      next[key] = Math.round(parsed * 60_000);
+    }
+    onChange(Object.keys(next).length ? next : undefined);
+  };
+  const monotone = idlePolicyIsMonotone(value);
+  return (
+    <Field>
+      <FieldLabel>Idle policy (minutes, optional)</FieldLabel>
+      <div className="grid gap-2 sm:grid-cols-2">
+        {IDLE_STAGES.map((stage) => (
+          <label key={stage.key} className="flex flex-col gap-1 text-xs">
+            <span className="text-muted-foreground">{stage.label}</span>
+            <Input
+              type="number"
+              min={1}
+              step={1}
+              value={value?.[stage.key] ? String((value[stage.key] ?? 0) / 60_000) : ""}
+              placeholder="—"
+              title={stage.hint}
+              onChange={(event) => update(stage.key, event.target.value)}
+            />
+          </label>
+        ))}
+      </div>
+      <FieldDescription
+        className={
+          !monotone
+            ? "text-xs text-destructive"
+            : warning
+              ? "text-xs text-amber-700 dark:text-amber-400"
+              : "text-xs"
+        }
+      >
+        {!monotone
+          ? "Stages must be non-decreasing: pause ≤ suspend ≤ stop ≤ close."
+          : warning
+            ?? "Measured from the environment's own idle clock; each later stage must not come before an earlier one. The environment wakes automatically when a session uses it."}
+      </FieldDescription>
+    </Field>
+  );
+}

--- a/platform/web/src/components/environment/power-controls.tsx
+++ b/platform/web/src/components/environment/power-controls.tsx
@@ -1,0 +1,107 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { api, type Environment } from "@/api";
+import { Button } from "@/components/ui/button";
+
+/// Observed steady power state derived from the lifecycle status (P126).
+export function observedPower(environment: Environment): Environment["desiredPower"] | null {
+  switch (environment.status) {
+    case "ready":
+      return "running";
+    case "paused":
+      return "paused";
+    case "suspended":
+      return "suspended";
+    case "offline":
+      return "stopped";
+    default:
+      return null;
+  }
+}
+
+export function powerDiverges(environment: Environment): boolean {
+  if (environment.source.type !== "provisioned") return false;
+  const observed = observedPower(environment);
+  return observed !== null && observed !== environment.desiredPower;
+}
+
+const IDLE_STAGES: Array<[keyof NonNullable<Environment["idlePolicy"]>, string]> = [
+  ["pauseAfterMs", "pause"],
+  ["suspendAfterMs", "suspend"],
+  ["stopAfterMs", "stop"],
+  ["closeAfterMs", "close"],
+];
+
+export function describeIdlePolicy(policy: Environment["idlePolicy"] | undefined): string {
+  if (!policy) return "none";
+  const stages = IDLE_STAGES
+    .filter(([key]) => policy[key] !== undefined && policy[key] !== null)
+    .map(([key, label]) => `${label} after ${formatDuration(policy[key] as number)}`);
+  return stages.length ? stages.join(", ") : "none";
+}
+
+export function formatDuration(ms: number): string {
+  if (ms % 3_600_000 === 0) return `${ms / 3_600_000}h`;
+  if (ms % 60_000 === 0) return `${ms / 60_000}m`;
+  if (ms % 1_000 === 0) return `${ms / 1_000}s`;
+  return `${ms}ms`;
+}
+
+/// Power intent (P126): pause/suspend/stop/resume a provisioned environment.
+/// Only the states the provider reported are offered; a powered-down
+/// environment also wakes by itself when a session uses it. `onChanged`
+/// lets a caller refresh its own query on top of the environments list.
+export function EnvironmentPowerControls({
+  universeId,
+  environment,
+  onChanged,
+}: {
+  universeId: string;
+  environment: Environment;
+  onChanged?: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const power = useMutation({
+    mutationFn: (next: Environment["desiredPower"]) => api<Environment>(
+      "PUT",
+      `/api/v1/universes/${universeId}/environments/${encodeURIComponent(environment.environmentId)}/power`,
+      { power: next },
+    ),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["environments", universeId] });
+      onChanged?.();
+    },
+  });
+  const supported = environment.incarnation.powerStates ?? [];
+  const closed = ["closing", "closed", "failed"].includes(environment.status);
+  if (closed || supported.length === 0) return null;
+  const busy = power.isPending || powerDiverges(environment);
+  const observed = observedPower(environment);
+  const options: Array<[Environment["desiredPower"], string]> = [
+    ["running", "Resume"],
+    ["paused", "Pause"],
+    ["suspended", "Suspend"],
+    ["stopped", "Stop"],
+  ];
+  return (
+    <>
+      {options
+        .filter(([state]) => supported.includes(state) && state !== environment.desiredPower)
+        .filter(([state]) => (state === "running" ? observed !== "running" : observed === "running" || observed === null))
+        .map(([state, label]) => (
+          <Button
+            key={state}
+            variant="outline"
+            size="xs"
+            disabled={busy}
+            onClick={() => power.mutate(state)}
+          >
+            {label}
+          </Button>
+        ))}
+      {busy && !power.isPending && (
+        <span className="text-xs text-muted-foreground">Converging to {environment.desiredPower}…</span>
+      )}
+      {power.error && <span className="text-xs text-destructive">{power.error.message}</span>}
+    </>
+  );
+}

--- a/platform/web/src/components/session/profile-environment-editor.tsx
+++ b/platform/web/src/components/session/profile-environment-editor.tsx
@@ -18,6 +18,7 @@ import {
   environmentCredentialSourceValue,
 } from "@/lib/environment-credentials";
 import { isTerminalEnvironmentStatus, selectableEnvironments } from "@/lib/sessions/resource-features";
+import { IdlePolicyFields } from "@/components/environment/idle-policy-fields";
 
 export type EnvironmentOption = {
   environmentId: string;
@@ -233,7 +234,7 @@ function ExistingEnvironmentField({
           ? "This saved environment is no longer available."
           : closed
             ? "This saved environment is closed and can no longer be activated."
-            : "The profile activates this environment and never closes it. Closed environments are not offered."}
+            : "The profile activates this environment and never closes it; a bot's sessions share it this way. Whether it sleeps while idle is the environment's own idle policy, set on the Environments page. Closed environments are not offered."}
       </FieldDescription>
     </Field>
   );
@@ -389,67 +390,6 @@ function ProvisionFields({
         }}
       />
     </>
-  );
-}
-
-type IdlePolicy = NonNullable<Extract<ProfileEnvironment, { type: "provision" }>["idlePolicy"]>;
-
-const IDLE_STAGES: Array<{ key: keyof IdlePolicy; label: string; hint: string }> = [
-  { key: "pauseAfterMs", label: "Pause after", hint: "Freeze execution; RAM stays resident, resume is instant." },
-  { key: "suspendAfterMs", label: "Suspend after", hint: "Save state to disk and free RAM (providers that support it)." },
-  { key: "stopAfterMs", label: "Stop after", hint: "Power off; disk is kept, resume is a fresh boot." },
-  { key: "closeAfterMs", label: "Close after", hint: "Destroy the environment." },
-];
-
-/// Idle policy (P126): minutes of daemon-reported idle time per stage. Empty
-/// stages are omitted; stages the provider cannot realize are skipped at
-/// runtime. A powered-down environment wakes when a session uses it.
-function IdlePolicyFields({
-  value,
-  onChange,
-}: {
-  value: IdlePolicy | undefined;
-  onChange: (policy: IdlePolicy | undefined) => void;
-}) {
-  const update = (key: keyof IdlePolicy, minutes: string) => {
-    const next: IdlePolicy = { ...(value ?? {}) };
-    const parsed = Number(minutes);
-    if (!minutes.trim() || !Number.isFinite(parsed) || parsed <= 0) {
-      delete next[key];
-    } else {
-      next[key] = Math.round(parsed * 60_000);
-    }
-    onChange(Object.keys(next).length ? next : undefined);
-  };
-  const ordered = IDLE_STAGES
-    .map((stage) => value?.[stage.key])
-    .filter((ms): ms is number => typeof ms === "number");
-  const monotone = ordered.every((ms, index) => index === 0 || ms >= (ordered[index - 1] ?? 0));
-  return (
-    <Field>
-      <FieldLabel>Idle policy (minutes, optional)</FieldLabel>
-      <div className="grid gap-2 sm:grid-cols-2">
-        {IDLE_STAGES.map((stage) => (
-          <label key={stage.key} className="flex flex-col gap-1 text-xs">
-            <span className="text-muted-foreground">{stage.label}</span>
-            <Input
-              type="number"
-              min={1}
-              step={1}
-              value={value?.[stage.key] ? String((value[stage.key] ?? 0) / 60_000) : ""}
-              placeholder="—"
-              title={stage.hint}
-              onChange={(event) => update(stage.key, event.target.value)}
-            />
-          </label>
-        ))}
-      </div>
-      <FieldDescription className={monotone ? "text-xs" : "text-xs text-destructive"}>
-        {monotone
-          ? "Measured from the environment's own idle clock; each later stage must not come before an earlier one. The environment wakes automatically when a session uses it."
-          : "Stages must be non-decreasing: pause ≤ suspend ≤ stop ≤ close."}
-      </FieldDescription>
-    </Field>
   );
 }
 

--- a/platform/web/src/pages/BotsPage.tsx
+++ b/platform/web/src/pages/BotsPage.tsx
@@ -110,7 +110,11 @@ function BotsPane({
                     <Badge variant="secondary" className="max-w-28 truncate" title={`Profile: ${bot.profileId}`}>
                       {bot.profileId}
                     </Badge>
-                    {!bot.enabled && <span className="shrink-0 text-xs text-destructive">Disabled</span>}
+                    {bot.closedAt ? (
+                      <span className="shrink-0 text-xs text-muted-foreground">Closed</span>
+                    ) : (
+                      !bot.enabled && <span className="shrink-0 text-xs text-destructive">Disabled</span>
+                    )}
                   </span>
                   <span className="mt-0.5 flex min-w-0 gap-2 text-xs text-muted-foreground">
                     <span className="min-w-0 flex-1 truncate" title={preview}>{preview}</span>

--- a/platform/web/src/pages/EnvironmentsPage.tsx
+++ b/platform/web/src/pages/EnvironmentsPage.tsx
@@ -45,6 +45,18 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { LoadingNote, PageHeader, UniverseNotFound } from "@/components/page";
+import { EnvironmentIdlePolicyDialog } from "@/components/environment/idle-policy-dialog";
+import {
+  IdlePolicyFields,
+  idlePolicyIsMonotone,
+  type IdlePolicy,
+} from "@/components/environment/idle-policy-fields";
+import {
+  EnvironmentPowerControls,
+  describeIdlePolicy,
+  observedPower,
+  powerDiverges,
+} from "@/components/environment/power-controls";
 import {
   environmentCredentialAvailable,
   environmentCredentialOptions,
@@ -214,7 +226,9 @@ function EnvironmentCard({
   secrets: SecretsInventory | undefined;
 }) {
   const [open, setOpen] = useState(false);
+  const [policyOpen, setPolicyOpen] = useState(false);
   const source = environment.source;
+  const gone = ["closing", "closed", "failed"].includes(environment.status);
 
   return (
     <Collapsible open={open} onOpenChange={setOpen}>
@@ -279,11 +293,25 @@ function EnvironmentCard({
             {source.type === "provisioned" && (
               <div className="mt-4 flex flex-wrap items-center gap-2 border-t pt-4">
                 <EnvironmentPowerControls universeId={universeId} environment={environment} />
+                {!gone && (
+                  <Button variant="outline" size="xs" onClick={() => setPolicyOpen(true)}>
+                    Idle policy…
+                  </Button>
+                )}
                 {template?.publicIngress && (
                   <EnvironmentIngressButton universeId={universeId} environment={environment} />
                 )}
                 <CloseEnvironmentButton universeId={universeId} environment={environment} />
               </div>
+            )}
+            {source.type === "provisioned" && !gone && (
+              <EnvironmentIdlePolicyDialog
+                key={`${environment.environmentId}:${policyOpen ? "open" : "closed"}`}
+                universeId={universeId}
+                environment={environment}
+                open={policyOpen}
+                onOpenChange={setPolicyOpen}
+              />
             )}
           </div>
         </CollapsibleContent>
@@ -564,50 +592,6 @@ function AssignCredentialDialog({
   );
 }
 
-/// Observed steady power state derived from the lifecycle status (P126).
-function observedPower(environment: Environment): Environment["desiredPower"] | null {
-  switch (environment.status) {
-    case "ready":
-      return "running";
-    case "paused":
-      return "paused";
-    case "suspended":
-      return "suspended";
-    case "offline":
-      return "stopped";
-    default:
-      return null;
-  }
-}
-
-function powerDiverges(environment: Environment): boolean {
-  if (environment.source.type !== "provisioned") return false;
-  const observed = observedPower(environment);
-  return observed !== null && observed !== environment.desiredPower;
-}
-
-const IDLE_STAGES: Array<[keyof NonNullable<Environment["idlePolicy"]>, string]> = [
-  ["pauseAfterMs", "pause"],
-  ["suspendAfterMs", "suspend"],
-  ["stopAfterMs", "stop"],
-  ["closeAfterMs", "close"],
-];
-
-function describeIdlePolicy(policy: Environment["idlePolicy"] | undefined): string {
-  if (!policy) return "none";
-  const stages = IDLE_STAGES
-    .filter(([key]) => policy[key] !== undefined && policy[key] !== null)
-    .map(([key, label]) => `${label} after ${formatDuration(policy[key] as number)}`);
-  return stages.length ? stages.join(", ") : "none";
-}
-
-function formatDuration(ms: number): string {
-  if (ms % 3_600_000 === 0) return `${ms / 3_600_000}h`;
-  if (ms % 60_000 === 0) return `${ms / 60_000}m`;
-  if (ms % 1_000 === 0) return `${ms / 1_000}s`;
-  return `${ms}ms`;
-}
-
 function EnvironmentStatusBadge({ environment }: { environment: Environment }) {
   if (environment.status === "ready") {
     return <Badge variant="secondary">ready</Badge>;
@@ -685,60 +669,6 @@ function ProviderStatusBadge({ status }: { status: EnvironmentProviderBinding["s
     <Badge variant="outline" className="border-destructive/50 text-destructive">
       {status}
     </Badge>
-  );
-}
-
-/// Power intent (P126): pause/suspend/stop/resume a provisioned environment.
-/// Only the states the provider reported are offered; a powered-down
-/// environment also wakes by itself when a session selects it.
-function EnvironmentPowerControls({
-  universeId,
-  environment,
-}: {
-  universeId: string;
-  environment: Environment;
-}) {
-  const queryClient = useQueryClient();
-  const power = useMutation({
-    mutationFn: (next: Environment["desiredPower"]) => api<Environment>(
-      "PUT",
-      `/api/v1/universes/${universeId}/environments/${encodeURIComponent(environment.environmentId)}/power`,
-      { power: next },
-    ),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["environments", universeId] }),
-  });
-  const supported = environment.incarnation.powerStates ?? [];
-  const closed = ["closing", "closed", "failed"].includes(environment.status);
-  if (closed || supported.length === 0) return null;
-  const busy = power.isPending || powerDiverges(environment);
-  const observed = observedPower(environment);
-  const options: Array<[Environment["desiredPower"], string]> = [
-    ["running", "Resume"],
-    ["paused", "Pause"],
-    ["suspended", "Suspend"],
-    ["stopped", "Stop"],
-  ];
-  return (
-    <>
-      {options
-        .filter(([state]) => supported.includes(state) && state !== environment.desiredPower)
-        .filter(([state]) => (state === "running" ? observed !== "running" : observed === "running" || observed === null))
-        .map(([state, label]) => (
-          <Button
-            key={state}
-            variant="outline"
-            size="xs"
-            disabled={busy}
-            onClick={() => power.mutate(state)}
-          >
-            {label}
-          </Button>
-        ))}
-      {busy && !power.isPending && (
-        <span className="text-xs text-muted-foreground">Converging to {environment.desiredPower}…</span>
-      )}
-      {power.error && <span className="text-xs text-destructive">{power.error.message}</span>}
-    </>
   );
 }
 
@@ -857,6 +787,7 @@ function CreateEnvironmentDialog({
   const [open, setOpen] = useState(false);
   const [templateKey, setTemplateKey] = useState("");
   const [displayName, setDisplayName] = useState("");
+  const [idlePolicy, setIdlePolicy] = useState<IdlePolicy | undefined>(undefined);
   const [requestId, setRequestId] = useState(() => crypto.randomUUID());
   const [error, setError] = useState<string | null>(null);
   const selectedTemplate = templates.find((template) =>
@@ -870,12 +801,14 @@ function CreateEnvironmentDialog({
         bindingId: selectedTemplate.bindingId,
         templateId: selectedTemplate.templateId,
         ...(displayName.trim() ? { displayName: displayName.trim() } : {}),
+        ...(idlePolicy ? { idlePolicy } : {}),
       });
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: ["environments", universeId] });
       setOpen(false);
       setDisplayName("");
+      setIdlePolicy(undefined);
       setRequestId(crypto.randomUUID());
       setError(null);
     },
@@ -938,11 +871,23 @@ function CreateEnvironmentDialog({
                   "Optional name shown throughout Lightspeed."}
               </FieldDescription>
             </Field>
+            <IdlePolicyFields
+              value={idlePolicy}
+              warning={
+                idlePolicy === undefined
+                  ? "No stages: the environment never sleeps while idle. A box a bot or several sessions share should at least pause. You can change this later from the environment's details."
+                  : undefined
+              }
+              onChange={setIdlePolicy}
+            />
             {error && <p className="text-sm text-destructive">{error}</p>}
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
-            <Button disabled={!selectedTemplate || create.isPending} onClick={() => create.mutate()}>
+            <Button
+              disabled={!selectedTemplate || create.isPending || !idlePolicyIsMonotone(idlePolicy)}
+              onClick={() => create.mutate()}
+            >
               {create.isPending ? "Provisioning…" : "Provision"}
             </Button>
           </DialogFooter>


### PR DESCRIPTION
## Summary
- add bot terminal close/delete lifecycle and teardown bookkeeping
- let bots use profile-owned existing environments for exec polls
- add bot/environment power and idle-policy controls to the web UI
- cancel pending environment power-down when work arrives

## Deployment note
The rebased 0002 Platform migration is intentionally updated in place. Production was prepared ahead of rollout by adding the nullable closed_at and closed_sessions columns to lightspeed_platform.public.bots.

## Validation
Required GitHub checks are the merge gate.