### PR TITLE
Refine bot setup flow

### DIFF
--- a/docs/roadmap/p141-bot-console.md
+++ b/docs/roadmap/p141-bot-console.md
@@ -145,11 +145,18 @@ of chrome and went. Every section saves on its own.
 - **Environment** — None / An existing environment (picker, then today's
   environment card with power controls and idle policy) / A fresh one per
   session (binding). Exec pollers explain themselves against this choice.
+- **Other bots** — both directions of bot-to-bot messaging in one place,
+  because that is one topic to a person even though it is a grant plus a
+  trigger to the system: "Can message other bots" (`emit`) and "Accepts
+  messages from: nobody / any bot / only …" (the `bot`-kind inbox trigger,
+  created and edited through the trigger API; "Routing & batching…" opens
+  the ordinary trigger editor). The Triggers section hides the inbox and
+  its picker omits "Other bots" so the record has one surface. Two earlier
+  placements — inbox under Guardrails, and inbox only under Triggers with
+  `emit` under Guardrails — split the topic and were replaced.
 - **Guardrails** — Daily run limit, Flood protection (breaker), Thread
   retention (routed TTL), "Can change its own brief and triggers"
-  (`selfConfig`), "Can message other bots" (`emit`), "Accepts messages
-  from other bots: off / any bot / only …" (the inbox trigger, presented
-  as a setting; the UI creates and deletes the `bot`-kind trigger).
+  (`selfConfig`).
 - **Danger zone** — Close, Delete, with today's copy.
 
 ## 4. Creating a bot: the wizard

--- a/platform/web/src/components/bot/detail.test.ts
+++ b/platform/web/src/components/bot/detail.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { BotLineage, BotState } from "@/api";
 import { conversationTabs } from "./detail";
-import { environmentSummary, guardrailsSummary } from "./setup-summary";
+import { environmentSummary, guardrailsSummary, otherBotsSummary } from "./setup-summary";
 
 function state(partial: Partial<BotState>): BotState {
   return {
@@ -87,14 +87,18 @@ describe("conversationTabs", () => {
 describe("setup summaries", () => {
   it("reads guardrails as one line", () => {
     expect(
-      guardrailsSummary(
-        { runsPerDay: 50, breaker: { fires: 20, windowMs: 600_000 }, routedSessionTtlMs: 7 * 86_400_000, selfConfig: true, emit: false },
-        ["release-shepherd"],
-      ),
-    ).toBe("50 runs a day · flood 20/10 min · threads close after 7d · can change own triggers · inbox: release-shepherd");
+      guardrailsSummary({
+        runsPerDay: 50,
+        breaker: { fires: 20, windowMs: 600_000 },
+        routedSessionTtlMs: 7 * 86_400_000,
+        selfConfig: true,
+      }),
+    ).toBe("50 runs a day · flood 20/10 min · threads close after 7d · can change own triggers");
     expect(
-      guardrailsSummary({ runsPerDay: null, breaker: null, routedSessionTtlMs: null, selfConfig: false, emit: true }, "off"),
-    ).toBe("no daily limit · threads kept · can message bots · no inbox");
+      guardrailsSummary({ runsPerDay: null, breaker: null, routedSessionTtlMs: null, selfConfig: false }),
+    ).toBe("no daily limit · threads kept");
+    expect(otherBotsSummary(true, ["release-shepherd"])).toBe("can send · receives from release-shepherd");
+    expect(otherBotsSummary(false, "off")).toBe("cannot send · receives from nobody");
   });
   it("names the environment", () => {
     expect(environmentSummary(undefined)).toBe("No environment");

--- a/platform/web/src/components/bot/setup-summary.ts
+++ b/platform/web/src/components/bot/setup-summary.ts
@@ -46,17 +46,21 @@ export function briefSummary(brief: string | null): string {
 }
 
 export function guardrailsSummary(
-  bot: Pick<Bot, "runsPerDay" | "breaker" | "routedSessionTtlMs" | "selfConfig" | "emit">,
-  inbox: "off" | "any" | string[],
+  bot: Pick<Bot, "runsPerDay" | "breaker" | "routedSessionTtlMs" | "selfConfig">,
 ): string {
   return [
     bot.runsPerDay === null ? "no daily limit" : `${bot.runsPerDay} runs a day`,
     bot.breaker ? `flood ${bot.breaker.fires}/${Math.round(bot.breaker.windowMs / 60_000)} min` : null,
     bot.routedSessionTtlMs ? `threads close after ${Math.round(bot.routedSessionTtlMs / 86_400_000)}d` : "threads kept",
     bot.selfConfig ? "can change own triggers" : null,
-    bot.emit ? "can message bots" : null,
-    inbox === "off" ? "no inbox" : inbox === "any" ? "inbox: any bot" : `inbox: ${inbox.join(", ")}`,
   ]
     .filter((part): part is string => part !== null)
     .join(" · ");
+}
+
+/** Both directions of bot-to-bot messaging in one line. */
+export function otherBotsSummary(emit: boolean, inbox: "off" | "any" | string[]): string {
+  const receive =
+    inbox === "off" ? "receives from nobody" : inbox === "any" ? "receives from any bot" : `receives from ${inbox.join(", ")}`;
+  return `${emit ? "can send" : "cannot send"} · ${receive}`;
 }

--- a/platform/web/src/components/bot/setup.tsx
+++ b/platform/web/src/components/bot/setup.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ArrowUpRight, ChevronRight } from "lucide-react";
+import { ArrowUpRight, ChevronRight, SlidersHorizontal } from "lucide-react";
 import { Link, useNavigate } from "react-router-dom";
 import {
   api,
@@ -51,9 +51,15 @@ import {
 import { cn } from "@/lib/utils";
 import { BotEnvironmentCard } from "./environment-card";
 import { BotAvatar } from "./face";
-import { briefSummary, capabilitySummary, environmentSummary, guardrailsSummary } from "./setup-summary";
+import { briefSummary, capabilitySummary, environmentSummary, guardrailsSummary, otherBotsSummary } from "./setup-summary";
 import { triggerSummary } from "./trigger-summary";
-import { BotMultiSelect, TriggersSection, inboxSelectionSpec, type BotEnvStatus } from "./triggers";
+import {
+  BotMultiSelect,
+  EditTriggerDialog,
+  TriggersSection,
+  inboxSelectionSpec,
+  type BotEnvStatus,
+} from "./triggers";
 
 /**
  * Everything about how a bot works, as a stack of sections that each read
@@ -95,13 +101,14 @@ export function BotSetup({
           ? { kind: "existing", environmentId: profile.data.environment.environmentId }
           : { kind: "provision" };
   const triggerList = triggers.data?.triggers ?? [];
+  const wakeups = triggerList.filter((trigger) => trigger.kind !== "bot");
   const triggersLine =
-    triggerList.length === 0
+    wakeups.length === 0
       ? "Nothing wakes it yet — you can always message it"
-      : `${triggerList.length} ${triggerList.length === 1 ? "trigger" : "triggers"} · ${triggerList
+      : `${wakeups.length} ${wakeups.length === 1 ? "trigger" : "triggers"} · ${wakeups
           .slice(0, 2)
           .map((trigger) => `${trigger.name}: ${triggerSummary(trigger)}`)
-          .join(" · ")}${triggerList.length > 2 ? " · …" : ""}`;
+          .join(" · ")}${wakeups.length > 2 ? " · …" : ""}`;
 
   return (
     <div className="min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto">
@@ -115,10 +122,18 @@ export function BotSetup({
           summary={triggersLine}
           defaultOpen
         >
-          <TriggersSection universeId={bot.universeId} botId={bot.botId} manage={manage} env={env} headless />
+          <TriggersSection
+            universeId={bot.universeId}
+            botId={bot.botId}
+            manage={manage}
+            env={env}
+            headless
+            hideKinds={["bot"]}
+          />
         </SetupSection>
+        <OtherBotsSection bot={bot} manage={manage} inbox={triggerList.find((trigger) => trigger.kind === "bot")} />
         <ProfileSections slug={slug} bot={bot} manage={manage} profile={profile.data} profileError={profile.error?.message} />
-        <GuardrailsSection bot={bot} state={state} manage={manage} triggers={triggerList} />
+        <GuardrailsSection bot={bot} state={state} manage={manage} />
         <DangerSection slug={slug} bot={bot} manage={manage} />
       </div>
     </div>
@@ -606,52 +621,22 @@ function ProfileSwitcher({
   );
 }
 
-type InboxMode = "off" | "any" | "selected";
-
-function GuardrailsSection({
-  bot,
-  state,
-  manage,
-  triggers: triggerList,
-}: {
-  bot: Bot;
-  state?: BotState;
-  manage: boolean;
-  triggers: BotTrigger[];
-}) {
+function GuardrailsSection({ bot, state, manage }: { bot: Bot; state?: BotState; manage: boolean }) {
   const queryClient = useQueryClient();
   const universeId = bot.universeId;
-  const bots = useQuery({
-    queryKey: ["bots", universeId],
-    queryFn: () => api<{ bots: BotListItem[] }>("GET", `/api/v1/universes/${universeId}/bots`),
-    enabled: manage,
-  });
-  const inbox = triggerList.find((trigger) => trigger.kind === "bot");
-  const inboxSpec = inbox?.spec as BotInboxSpec | undefined;
-  const baseInboxMode: InboxMode = !inbox ? "off" : inboxSpec?.from === undefined ? "any" : "selected";
-  const baseInboxIds = inboxSpec?.from ?? [];
 
   const [runsPerDay, setRunsPerDay] = useState(bot.runsPerDay?.toString() ?? "");
   const [breakerFires, setBreakerFires] = useState(bot.breaker?.fires.toString() ?? "");
   const [breakerWindow, setBreakerWindow] = useState(bot.breaker ? String(Math.round(bot.breaker.windowMs / 60_000)) : "");
   const [ttlDays, setTtlDays] = useState(bot.routedSessionTtlMs ? String(Math.round(bot.routedSessionTtlMs / 86_400_000)) : "");
   const [selfConfig, setSelfConfig] = useState(bot.selfConfig);
-  const [emit, setEmit] = useState(bot.emit);
-  const [inboxMode, setInboxMode] = useState<InboxMode>(baseInboxMode);
-  const [inboxIds, setInboxIds] = useState<string[]>(baseInboxIds);
   useEffect(() => {
     setRunsPerDay(bot.runsPerDay?.toString() ?? "");
     setBreakerFires(bot.breaker?.fires.toString() ?? "");
     setBreakerWindow(bot.breaker ? String(Math.round(bot.breaker.windowMs / 60_000)) : "");
     setTtlDays(bot.routedSessionTtlMs ? String(Math.round(bot.routedSessionTtlMs / 86_400_000)) : "");
     setSelfConfig(bot.selfConfig);
-    setEmit(bot.emit);
-  }, [bot.runsPerDay, bot.breaker, bot.routedSessionTtlMs, bot.selfConfig, bot.emit]);
-  useEffect(() => {
-    setInboxMode(baseInboxMode);
-    setInboxIds(baseInboxIds);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [inbox?.name, JSON.stringify(baseInboxIds), baseInboxMode]);
+  }, [bot.runsPerDay, bot.breaker, bot.routedSessionTtlMs, bot.selfConfig]);
 
   const fields = () => ({
     runsPerDay: runsPerDay.trim() ? Number(runsPerDay) : null,
@@ -660,7 +645,6 @@ function GuardrailsSection({
       : null,
     routedSessionTtlMs: ttlDays.trim() ? Math.round(Number(ttlDays) * 86_400_000) : null,
     selfConfig,
-    emit,
   });
   const botDirty =
     JSON.stringify(fields()) !==
@@ -669,40 +653,17 @@ function GuardrailsSection({
       breaker: bot.breaker,
       routedSessionTtlMs: bot.routedSessionTtlMs,
       selfConfig: bot.selfConfig,
-      emit: bot.emit,
     });
-  const inboxDirty =
-    inboxMode !== baseInboxMode ||
-    (inboxMode === "selected" && JSON.stringify([...inboxIds].sort()) !== JSON.stringify([...baseInboxIds].sort()));
-  const problem =
-    inboxMode === "selected" && inboxIds.length === 0
-      ? "Choose at least one bot, or allow any bot."
-      : ttlDays.trim() && !(Number(ttlDays) >= 1)
-        ? "Thread retention is at least one day."
-        : null;
+  const problem = ttlDays.trim() && !(Number(ttlDays) >= 1) ? "Thread retention is at least one day." : null;
 
   const save = useMutation({
-    mutationFn: async () => {
-      if (botDirty) {
-        await api<{ bot: Bot }>("PATCH", `/api/v1/universes/${universeId}/bots/${bot.botId}`, fields());
-      }
-      if (inboxDirty) {
-        const url = `/api/v1/universes/${universeId}/bots/${bot.botId}/triggers`;
-        if (inboxMode === "off") {
-          if (inbox) await api("DELETE", `${url}/${inbox.name}`);
-        } else {
-          const spec = inboxSelectionSpec(inboxMode === "any" ? "any" : "selected", inboxIds);
-          if (inbox) await api("PATCH", `${url}/${inbox.name}`, { spec });
-          else await api("POST", url, { name: "inbox", kind: "bot", spec });
-        }
-      }
-    },
-    onSuccess: async () => {
+    mutationFn: () =>
+      api<{ bot: Bot }>("PATCH", `/api/v1/universes/${universeId}/bots/${bot.botId}`, fields()),
+    onSuccess: async ({ bot: updated }) => {
+      queryClient.setQueryData(["bot", universeId, bot.botId], { bot: updated });
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ["bot", universeId, bot.botId] }),
         queryClient.invalidateQueries({ queryKey: ["bots", universeId] }),
         queryClient.invalidateQueries({ queryKey: ["bot-state", universeId, bot.botId] }),
-        queryClient.invalidateQueries({ queryKey: ["bot-triggers", universeId, bot.botId] }),
       ]);
     },
   });
@@ -715,7 +676,7 @@ function GuardrailsSection({
       id="guardrails"
       title="Guardrails"
       description="Limits and permissions."
-      summary={guardrailsSummary(bot, baseInboxMode === "off" ? "off" : baseInboxMode === "any" ? "any" : baseInboxIds)}
+      summary={guardrailsSummary(bot)}
     >
       <div className="grid gap-4 sm:grid-cols-2">
         <Field>
@@ -789,46 +750,178 @@ function GuardrailsSection({
           onCheckedChange={setSelfConfig}
           disabled={readOnly}
         />
-        <ToggleRow
-          id="bot-emit"
-          label="Can message other bots"
-          hint="Discovers bots that accept it and addresses them with bot_emit; may also post to itself. Rate-capped."
-          checked={emit}
-          onCheckedChange={setEmit}
-          disabled={readOnly}
-        />
-        <div className="grid gap-2 rounded-md border p-3">
-          <div className="flex items-center justify-between gap-3">
-            <Label htmlFor="bot-inbox-mode" className="text-sm">
-              Accepts messages from other bots
-              <span className="block text-xs font-normal text-muted-foreground">
-                Its inbox: which bots may address it. The inbox is a trigger; routing and batching are edited there.
-              </span>
-            </Label>
-            <Select value={inboxMode} onValueChange={(value) => value && setInboxMode(value as InboxMode)} disabled={readOnly}>
-              <SelectTrigger id="bot-inbox-mode" size="sm" className="w-40">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="off">Nobody</SelectItem>
-                <SelectItem value="any">Any bot here</SelectItem>
-                <SelectItem value="selected">Only these bots</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-          {inboxMode === "selected" && (
-            <BotMultiSelect currentBotId={bot.botId} bots={bots.data?.bots ?? []} value={inboxIds} onChange={setInboxIds} />
-          )}
-        </div>
       </div>
       {manage && (
         <SaveRow
-          dirty={botDirty || inboxDirty}
+          dirty={botDirty}
           pending={save.isPending}
           error={problem ?? save.error?.message}
           disabled={closed || problem !== null}
           onSave={() => save.mutate()}
           note="Grants change the bot's toolset; its sessions pick that up at their next idle moment."
+        />
+      )}
+    </SetupSection>
+  );
+}
+
+type InboxMode = "off" | "any" | "selected";
+
+/**
+ * Talking to other bots, both directions in one place: sending is a grant
+ * on this bot (`emit`); receiving is its inbox — a trigger under the hood,
+ * with the routing and batching of one, shown here in the person's words.
+ */
+function OtherBotsSection({ bot, manage, inbox }: { bot: Bot; manage: boolean; inbox: BotTrigger | undefined }) {
+  const queryClient = useQueryClient();
+  const universeId = bot.universeId;
+  const bots = useQuery({
+    queryKey: ["bots", universeId],
+    queryFn: () => api<{ bots: BotListItem[] }>("GET", `/api/v1/universes/${universeId}/bots`),
+  });
+  const inboxSpec = inbox?.spec as BotInboxSpec | undefined;
+  // A paused inbox reads as "Nobody" but keeps its sender list and routing,
+  // so switching receiving back on restores them.
+  const paused = inbox !== undefined && !inbox.enabled;
+  const baseMode: InboxMode = !inbox || paused ? "off" : inboxSpec?.from === undefined ? "any" : "selected";
+  const baseIds = inboxSpec?.from ?? [];
+  const [emit, setEmit] = useState(bot.emit);
+  const [mode, setMode] = useState<InboxMode>(baseMode);
+  const [ids, setIds] = useState<string[]>(baseIds);
+  const [editingInbox, setEditingInbox] = useState(false);
+  useEffect(() => setEmit(bot.emit), [bot.emit]);
+  useEffect(() => {
+    setMode(baseMode);
+    setIds(baseIds);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inbox?.name, baseMode, JSON.stringify(baseIds)]);
+
+  const emitDirty = emit !== bot.emit;
+  const inboxDirty =
+    mode !== baseMode || (mode === "selected" && JSON.stringify([...ids].sort()) !== JSON.stringify([...baseIds].sort()));
+  const problem = mode === "selected" && ids.length === 0 ? "Choose at least one bot, or allow any bot." : null;
+  const save = useMutation({
+    mutationFn: async () => {
+      if (emitDirty) {
+        await api<{ bot: Bot }>("PATCH", `/api/v1/universes/${universeId}/bots/${bot.botId}`, { emit });
+      }
+      if (inboxDirty) {
+        const url = `/api/v1/universes/${universeId}/bots/${bot.botId}/triggers`;
+        if (mode === "off") {
+          // Pause, never delete: the sender list and routing survive.
+          if (inbox && inbox.enabled) await api("PATCH", `${url}/${inbox.name}`, { enabled: false });
+        } else {
+          const spec = inboxSelectionSpec(mode === "any" ? "any" : "selected", ids);
+          if (inbox) await api("PATCH", `${url}/${inbox.name}`, { spec, enabled: true });
+          else await api("POST", url, { name: "inbox", kind: "bot", spec });
+        }
+      }
+    },
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["bot", universeId, bot.botId] }),
+        queryClient.invalidateQueries({ queryKey: ["bots", universeId] }),
+        queryClient.invalidateQueries({ queryKey: ["bot-state", universeId, bot.botId] }),
+        queryClient.invalidateQueries({ queryKey: ["bot-triggers", universeId, bot.botId] }),
+      ]);
+    },
+  });
+  const closed = bot.closedAt !== null;
+  const readOnly = !manage || closed;
+  const others = (bots.data?.bots ?? []).filter((other) => other.botId !== bot.botId && !other.closedAt);
+
+  return (
+    <SetupSection
+      id="other-bots"
+      title="Other bots"
+      description="Bots in this universe can message each other; every message is an event, and each side decides for itself."
+      summary={otherBotsSummary(bot.emit, baseMode === "off" ? "off" : baseMode === "any" ? "any" : baseIds)}
+    >
+      <ToggleRow
+        id="bot-emit"
+        label="Can message other bots"
+        hint="Sees which bots accept it and addresses them by id; may also post to itself. Rate-capped, and a message travels at most a few hops. Turning this on also opens the inbox — sending without listening is the rare case."
+        checked={emit}
+        onCheckedChange={(checked) => {
+          setEmit(checked);
+          if (checked && mode === "off") setMode("any");
+        }}
+        disabled={readOnly}
+      />
+      <div className="grid gap-2 rounded-md border p-3">
+        <div className="flex items-center justify-between gap-3">
+          <Label htmlFor="bot-inbox-mode" className="text-sm">
+            Accepts messages from
+            <span className="block text-xs font-normal text-muted-foreground">
+              {others.length === 0
+                ? "There are no other bots in this universe yet."
+                : "Which bots may address this one. Messages from them arrive like any other event."}
+            </span>
+          </Label>
+          <Select value={mode} onValueChange={(value) => value && setMode(value as InboxMode)} disabled={readOnly}>
+            <SelectTrigger id="bot-inbox-mode" size="sm" className="w-40">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="off">Nobody</SelectItem>
+              <SelectItem value="any">Any bot here</SelectItem>
+              <SelectItem value="selected">Only these bots</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        {mode === "selected" && (
+          <BotMultiSelect currentBotId={bot.botId} bots={bots.data?.bots ?? []} value={ids} onChange={setIds} />
+        )}
+        {mode !== "off" && manage && (
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={!inbox || inboxDirty}
+              onClick={() => setEditingInbox(true)}
+              title={!inbox || inboxDirty ? "Save first, then set routing and batching." : undefined}
+            >
+              <SlidersHorizontal data-icon="inline-start" /> Routing &amp; batching…
+            </Button>
+            <span className="text-xs text-muted-foreground">
+              {!inbox || inboxDirty
+                ? "Available after you save."
+                : inbox.route?.policy === "perKey"
+                  ? "One thread per key."
+                  : inbox.route?.policy === "perEvent"
+                    ? "One thread per message."
+                    : "Messages arrive in Main."}
+            </span>
+          </div>
+        )}
+        {mode === "off" && paused && (
+          <p className="text-xs text-muted-foreground">
+            Inbox paused{inbox?.disabledReason === "breaker" ? " by flood protection" : ""}; its sender list and
+            routing are kept.
+          </p>
+        )}
+      </div>
+      {manage && (
+        <SaveRow
+          dirty={emitDirty || inboxDirty}
+          pending={save.isPending}
+          error={problem ?? save.error?.message}
+          disabled={closed || problem !== null}
+          onSave={() => save.mutate()}
+          note="Sending is a tool grant, picked up at the bot's next idle moment; receiving applies to the next message."
+        />
+      )}
+      {manage && inbox && editingInbox && (
+        <EditTriggerDialog
+          universeId={universeId}
+          botId={bot.botId}
+          bots={bots.data?.bots ?? []}
+          trigger={inbox}
+          open
+          deliveryOnly
+          onOpenChange={(open) => {
+            if (!open) setEditingInbox(false);
+          }}
         />
       )}
     </SetupSection>

--- a/platform/web/src/components/bot/templates.ts
+++ b/platform/web/src/components/bot/templates.ts
@@ -1,4 +1,4 @@
-/// Starting points for the creation wizard: a job description, the wake-ups
+/// Starting points for the creation wizard: a job description, the triggers
 /// that fit it, and the capabilities it needs. Templates only prefill the
 /// form — everything stays editable before Create, and after.
 export type TemplateTrigger =
@@ -27,7 +27,7 @@ export const BOT_TEMPLATES: BotTemplate[] = [
     id: "blank",
     name: "Blank",
     suggestedName: null,
-    description: "Start from nothing: you write the brief and pick the wake-ups.",
+    description: "Start from nothing: you write the brief and pick the triggers.",
     brief: "",
     features: {},
     triggers: [],

--- a/platform/web/src/components/bot/triggers.tsx
+++ b/platform/web/src/components/bot/triggers.tsx
@@ -339,6 +339,7 @@ export function TriggersSection({
   env,
   id,
   headless = false,
+  hideKinds = [],
 }: {
   universeId: string;
   botId: string;
@@ -347,6 +348,8 @@ export function TriggersSection({
   id?: string;
   /** Rendered inside a section that already has a title; the add button moves under the list. */
   headless?: boolean;
+  /** Kinds another section presents in its own words (the inbox under "Other bots"). */
+  hideKinds?: TriggerKind[];
 }) {
   const queryClient = useQueryClient();
   const [addOpen, setAddOpen] = useState(false);
@@ -382,6 +385,7 @@ export function TriggersSection({
       return invalidate();
     },
   });
+  const visibleTriggers = (triggers.data?.triggers ?? []).filter((trigger) => !hideKinds.includes(trigger.kind));
   const sample = useMutation({
     mutationFn: sendSampleWebhook,
     onSuccess: () =>
@@ -406,7 +410,7 @@ export function TriggersSection({
           )}
         </div>
       )}
-      {triggers.data?.triggers.length === 0 && (
+      {visibleTriggers.length === 0 && (
         <p className="rounded-md border border-dashed p-3 text-xs text-muted-foreground">
           Nothing wakes this bot yet{manage ? " — add a schedule, a webhook, or a chat account. You can always message it from Chat." : "."}
         </p>
@@ -418,7 +422,7 @@ export function TriggersSection({
       {sample.isSuccess && (
         <p className="text-xs text-muted-foreground">Sample sent — it shows up under Activity in a moment.</p>
       )}
-      {triggers.data?.triggers.map((trigger) => {
+      {visibleTriggers.map((trigger) => {
         const exec = trigger.kind === "poll" && (trigger.spec as BotPollSpec).source.kind === "exec";
         const summary = triggerSummary(trigger);
         const delivery = deliverySentence(deliveryShapeOf(trigger), trigger.kind === "chat");
@@ -532,6 +536,7 @@ export function TriggersSection({
           env={env}
           open={addOpen}
           onOpenChange={setAddOpen}
+          excludeKinds={hideKinds}
         />
       )}
       {manage && editing && (
@@ -1986,10 +1991,12 @@ export function TriggerKindPicker({
   env,
   onPick,
   className,
+  exclude = [],
 }: {
   env: BotEnvStatus;
   onPick: (kind: TriggerKind, options?: { pollSource: "http" | "exec" }) => void;
   className?: string;
+  exclude?: TriggerKind[];
 }) {
   return (
     <div className={cn("grid content-start gap-3 sm:grid-cols-2", className)}>
@@ -2011,12 +2018,14 @@ export function TriggerKindPicker({
         description="Messages from people on Telegram or WhatsApp; each conversation becomes a thread."
         onClick={() => onPick("chat")}
       />
-      <TriggerKindChoice
-        icon={<Inbox className="size-5" />}
-        title="Other bots"
-        description="Let bots in this universe message this one (at most one inbox)."
-        onClick={() => onPick("bot")}
-      />
+      {!exclude.includes("bot") && (
+        <TriggerKindChoice
+          icon={<Inbox className="size-5" />}
+          title="Other bots"
+          description="Let bots in this universe message this one (at most one inbox)."
+          onClick={() => onPick("bot")}
+        />
+      )}
       <TriggerKindChoice
         icon={<RefreshCw className="size-5" />}
         title="Check a URL"
@@ -2050,6 +2059,7 @@ function AddTriggerDialog({
   env,
   open,
   onOpenChange,
+  excludeKinds = [],
 }: {
   universeId: string;
   botId: string;
@@ -2057,6 +2067,7 @@ function AddTriggerDialog({
   env: BotEnvStatus;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  excludeKinds?: TriggerKind[];
 }) {
   const queryClient = useQueryClient();
   const [kind, setKind] = useState<TriggerKind | null>(null);
@@ -2143,7 +2154,7 @@ function AddTriggerDialog({
         {!kind ? (
           <>
             <div className="min-h-0 overflow-y-auto p-6">
-              <TriggerKindPicker env={env} onPick={pick} />
+              <TriggerKindPicker env={env} onPick={pick} exclude={excludeKinds} />
             </div>
             <DialogFooter className="border-t p-4">
               <Button type="button" variant="outline" onClick={() => changeOpen(false)}>
@@ -2234,13 +2245,14 @@ export function TriggerKindChoice({
   );
 }
 
-function EditTriggerDialog({
+export function EditTriggerDialog({
   universeId,
   botId,
   bots,
   trigger,
   open,
   onOpenChange,
+  deliveryOnly = false,
 }: {
   universeId: string;
   botId: string;
@@ -2248,6 +2260,8 @@ function EditTriggerDialog({
   trigger: BotTrigger;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /** Only routing, batching, busy handling, and retention: the rest of the trigger is edited elsewhere (the inbox's sender list). */
+  deliveryOnly?: boolean;
 }) {
   const queryClient = useQueryClient();
   const scheduleSpec = trigger.kind === "schedule" ? (trigger.spec as BotScheduleSpec) : null;
@@ -2307,9 +2321,11 @@ function EditTriggerDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="h-[min(92dvh,900px)] grid-rows-[auto_minmax(0,1fr)_auto] gap-0 p-0 sm:max-w-xl">
         <DialogHeader className="border-b p-6 pr-14">
-          <DialogTitle>Edit {trigger.name}</DialogTitle>
+          <DialogTitle>{deliveryOnly ? "Routing & batching" : `Edit ${trigger.name}`}</DialogTitle>
           <DialogDescription>
-            {trigger.kind === "schedule"
+            {deliveryOnly
+              ? "How messages from other bots reach this bot: which conversation, whether they batch, and what happens while it is busy."
+              : trigger.kind === "schedule"
               ? "Changes apply to the next fire."
               : trigger.kind === "poll"
                 ? "Source changes reset the cursor: the next check re-baselines against the source."
@@ -2329,7 +2345,13 @@ function EditTriggerDialog({
           className="contents"
         >
           <div className="grid min-h-0 content-start gap-4 overflow-y-auto p-6">
-            {trigger.kind === "schedule" ? (
+            {deliveryOnly ? (
+              <DeliveryFieldsBody
+                form={forms.inbox}
+                setForm={(next) => patch("inbox", next)}
+                chat={trigger.kind === "chat"}
+              />
+            ) : trigger.kind === "schedule" ? (
               <ScheduleFields
                 form={forms.schedule}
                 setForm={(next) => patch("schedule", next)}

--- a/platform/web/src/pages/BotCreatePage.tsx
+++ b/platform/web/src/pages/BotCreatePage.tsx
@@ -11,10 +11,11 @@ import {
 } from "@/api";
 import { BotAvatar, botColor } from "@/components/bot/face";
 import { botIdFrom } from "@/components/bot/identity";
-import { capabilitySummary } from "@/components/bot/setup-summary";
+import { capabilitySummary, otherBotsSummary } from "@/components/bot/setup-summary";
 import { BOT_TEMPLATES, type BotTemplate } from "@/components/bot/templates";
 import { describeCron } from "@/components/bot/trigger-summary";
 import {
+  BotMultiSelect,
   NAME_PATTERN,
   TriggerKindFields,
   TriggerKindIcon,
@@ -51,10 +52,12 @@ import { hasSessionFeature, setupResourceFeatureError } from "@/lib/sessions/res
 import { canManage, useActiveUniverse } from "@/lib/universes";
 import { cn } from "@/lib/utils";
 
-type Step = "job" | "wakeups" | "capabilities" | "guardrails";
+type Step = "job" | "wakeups" | "bots" | "capabilities" | "guardrails";
+/** The same sections as the bot's Setup tab, in the same order. */
 const STEPS: Array<{ id: Step; label: string }> = [
   { id: "job", label: "Job" },
-  { id: "wakeups", label: "Wake-ups" },
+  { id: "wakeups", label: "Triggers" },
+  { id: "bots", label: "Other bots" },
   { id: "capabilities", label: "Capabilities" },
   { id: "guardrails", label: "Guardrails" },
 ];
@@ -75,7 +78,7 @@ export function uniqueTriggerName(base: string, taken: string[]): string {
   return `${base}-${index}`;
 }
 
-/** Plain words for a wake-up still being drafted, from its form. */
+/** Plain words for a trigger still being drafted, from its form. */
 export function wakeupSummary(draft: WakeupDraft): string {
   switch (draft.kind) {
     case "schedule": {
@@ -107,7 +110,7 @@ export function wakeupSummary(draft: WakeupDraft): string {
   }
 }
 
-/** What a template comes with, in a few words: its wake-ups, then its capabilities. */
+/** What a template comes with, in a few words: its triggers, then its capabilities. */
 export function templateHighlights(template: BotTemplate): string[] {
   const wakeups = template.triggers.map((trigger) => {
     switch (trigger.kind) {
@@ -164,6 +167,28 @@ function Wizard({ universeId, slug }: { universeId: string; slug: string }) {
   const [runsPerDay, setRunsPerDay] = useState("50");
   const [selfConfig, setSelfConfig] = useState(true);
   const [emit, setEmit] = useState(false);
+  // The inbox is a trigger draft like any other, but it is driven from the
+  // "Other bots" block, not the trigger picker, so send and receive sit together.
+  const inboxDraft = wakeups.find((draft) => draft.kind === "bot");
+  const inboxMode: "off" | "any" | "selected" =
+    !inboxDraft ? "off" : inboxDraft.forms.inbox.fromMode === "any" ? "any" : "selected";
+  const inboxIds = inboxDraft?.forms.inbox.fromBotIds ?? [];
+  const setInbox = (mode: "off" | "any" | "selected", ids: string[] = inboxIds) => {
+    setWakeups((current) => {
+      const without = current.filter((draft) => draft.kind !== "bot");
+      if (mode === "off") return without;
+      const existing = current.find((draft) => draft.kind === "bot");
+      const forms = existing?.forms ?? defaultTriggerForms();
+      const draft: WakeupDraft = {
+        key: existing?.key ?? crypto.randomUUID(),
+        kind: "bot",
+        name: existing?.name ?? uniqueTriggerName("inbox", without.map((entry) => entry.name)),
+        forms: { ...forms, inbox: { ...forms.inbox, fromMode: mode === "any" ? "any" : "selected", fromBotIds: ids } },
+      };
+      return [...without, draft];
+    });
+  };
+  const visibleWakeups = wakeups.filter((draft) => draft.kind !== "bot");
 
   const profiles = useQuery({
     queryKey: ["profiles", universeId],
@@ -233,7 +258,7 @@ function Wizard({ universeId, slug }: { universeId: string; slug: string }) {
       !draft.name.trim() || !NAME_PATTERN.test(draft.name.trim())
         ? "Give it a name in lowercase letters, numbers, and dashes."
         : wakeups.filter((other) => other.name.trim() === draft.name.trim()).length > 1
-          ? "Two wake-ups share this name."
+          ? "Two triggers share this name."
           : triggerFormProblem(draft.kind, draft.forms, env),
   }));
   const setupProblem =
@@ -247,7 +272,7 @@ function Wizard({ universeId, slug }: { universeId: string; slug: string }) {
     ...(idInvalid ? ["The id uses lowercase letters, numbers, and dashes."] : []),
     ...(idTaken ? [`A bot named ${botId.trim()} already exists.`] : []),
     ...(profileTaken ? [`A profile named ${botId.trim()} already exists — pick another id, or use it as a shared profile.`] : []),
-    ...wakeupProblems.filter((entry) => entry.problem).map((entry) => `Wake-up: ${entry.problem}`),
+    ...wakeupProblems.filter((entry) => entry.problem).map((entry) => `Trigger: ${entry.problem}`),
     ...(setupProblem ? [setupProblem] : []),
     ...(runsPerDay.trim() && !(Number(runsPerDay) >= 1) ? ["The daily run limit is at least 1."] : []),
   ];
@@ -372,9 +397,14 @@ function Wizard({ universeId, slug }: { universeId: string; slug: string }) {
             </div>
           </div>
           <SummaryRow label="Job">{brief.trim() ? brief.trim().slice(0, 140) + (brief.trim().length > 140 ? "…" : "") : <em>not written yet</em>}</SummaryRow>
-          <SummaryRow label="Wakes up">
-            {wakeups.length === 0 ? <em>only when you message it</em> : wakeups.map((draft) => <span key={draft.key} className="block truncate">{wakeupSummary(draft)}</span>)}
+          <SummaryRow label="Triggers">
+            {visibleWakeups.length === 0 ? <em>only when you message it</em> : visibleWakeups.map((draft) => <span key={draft.key} className="block truncate">{wakeupSummary(draft)}</span>)}
           </SummaryRow>
+          {(emit || inboxMode !== "off") && (
+            <SummaryRow label="Other bots">
+              {otherBotsSummary(emit, inboxMode === "off" ? "off" : inboxMode === "any" ? "any" : inboxIds)}
+            </SummaryRow>
+          )}
           <SummaryRow label="Can use">
             {setupMode === "shared"
               ? sharedProfileId
@@ -396,7 +426,6 @@ function Wizard({ universeId, slug }: { universeId: string; slug: string }) {
           <SummaryRow label="Limits">
             {runsPerDay.trim() ? `${runsPerDay} runs a day` : "no daily limit"}
             {selfConfig ? " · can change its own triggers" : ""}
-            {emit ? " · can message bots" : ""}
           </SummaryRow>
           {problems.length > 0 && (
             <ul className="grid gap-1 border-t pt-3 text-amber-700 dark:text-amber-400">
@@ -496,14 +525,14 @@ function Wizard({ universeId, slug }: { universeId: string; slug: string }) {
             <header className="grid gap-1">
               <h1 className="text-xl font-semibold tracking-tight">When should {label} wake up?</h1>
               <p className="text-sm text-muted-foreground">
-                Pick any that apply. You can always message it from Chat, and add more wake-ups later
+                Pick any that apply. You can always message it from Chat, and add more triggers later
                 {selfConfig ? " — or ask it to add them itself" : ""}.
               </p>
             </header>
-            <TriggerKindPicker env={env} onPick={addWakeup} />
-            {wakeups.length > 0 && (
+            <TriggerKindPicker env={env} onPick={addWakeup} exclude={["bot"]} />
+            {visibleWakeups.length > 0 && (
               <div className="grid gap-2">
-                {wakeups.map((draft) => {
+                {visibleWakeups.map((draft) => {
                   const problem = wakeupProblems.find((entry) => entry.key === draft.key)?.problem ?? null;
                   const open = openWakeup === draft.key;
                   return (
@@ -527,7 +556,7 @@ function Wizard({ universeId, slug }: { universeId: string; slug: string }) {
                         <Button
                           variant="ghost"
                           size="icon-sm"
-                          aria-label="Remove wake-up"
+                          aria-label="Remove trigger"
                           onClick={() => setWakeups((current) => current.filter((entry) => entry.key !== draft.key))}
                         >
                           <Trash2 />
@@ -560,6 +589,65 @@ function Wizard({ universeId, slug }: { universeId: string; slug: string }) {
                 })}
               </div>
             )}
+          </section>
+        )}
+
+        {step === "bots" && (
+          <section className="grid gap-5">
+            <header className="grid gap-1">
+              <h1 className="text-xl font-semibold tracking-tight">Should {label} talk to other bots?</h1>
+              <p className="text-sm text-muted-foreground">
+                Bots in this universe can message each other; every message is an event, and each side decides for
+                itself. Skip this if {label} works alone.
+              </p>
+            </header>
+            <div className="grid gap-2">
+              <div className="flex items-center justify-between gap-3 rounded-md border p-3">
+                <Label htmlFor="new-bot-emit" className="text-sm">
+                  Can message other bots
+                  <span className="block text-xs font-normal text-muted-foreground">
+                    Sees which bots accept it and addresses them by id; rate-capped. Turning this on also opens the inbox —
+                    sending without listening is the rare case.
+                  </span>
+                </Label>
+                <Switch
+                  id="new-bot-emit"
+                  checked={emit}
+                  onCheckedChange={(checked) => {
+                    setEmit(checked);
+                    if (checked && inboxMode === "off") setInbox("any");
+                  }}
+                />
+              </div>
+              <div className="grid gap-2 rounded-md border p-3">
+                <div className="flex items-center justify-between gap-3">
+                  <Label htmlFor="new-bot-inbox" className="text-sm">
+                    Accepts messages from
+                    <span className="block text-xs font-normal text-muted-foreground">
+                      Which bots may address this one. Routing and batching can be tuned under Setup later.
+                    </span>
+                  </Label>
+                  <Select value={inboxMode} onValueChange={(value) => value && setInbox(value as "off" | "any" | "selected")}>
+                    <SelectTrigger id="new-bot-inbox" size="sm" className="w-40">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="off">Nobody</SelectItem>
+                      <SelectItem value="any">Any bot here</SelectItem>
+                      <SelectItem value="selected">Only these bots</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                {inboxMode === "selected" && (
+                  <BotMultiSelect
+                    currentBotId={botId.trim() || "new-bot"}
+                    bots={(bots.data?.bots ?? []).map((bot) => ({ ...bot, triggerCount: 0, pendingCount: 0, lastEvent: null }))}
+                    value={inboxIds}
+                    onChange={(ids) => setInbox("selected", ids)}
+                  />
+                )}
+              </div>
+            </div>
           </section>
         )}
 
@@ -670,15 +758,6 @@ function Wizard({ universeId, slug }: { universeId: string; slug: string }) {
                   </span>
                 </Label>
                 <Switch id="new-bot-self-config" checked={selfConfig} onCheckedChange={setSelfConfig} />
-              </div>
-              <div className="flex items-center justify-between gap-3 rounded-md border p-3">
-                <Label htmlFor="new-bot-emit" className="text-sm">
-                  Can message other bots
-                  <span className="block text-xs font-normal text-muted-foreground">
-                    Discovers bots that accept it and addresses them; rate-capped. Receiving is a wake-up ("Other bots").
-                  </span>
-                </Label>
-                <Switch id="new-bot-emit" checked={emit} onCheckedChange={setEmit} />
               </div>
             </div>
           </section>


### PR DESCRIPTION
## Summary

- group bot-to-bot send and receive controls in a dedicated Other bots setup section
- keep the bot inbox out of the generic trigger list while preserving routing and batching controls
- align the creation wizard with the setup sections and use consistent trigger terminology
- update setup summaries, tests, and the bot-console roadmap

## Testing

- npm run test --workspace @lightspeed/platform-web
- npm run typecheck --workspace @lightspeed/platform-web
- npm run build --workspace @lightspeed/platform-web