### PR TITLE
Serve demo build under /demo/

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -85,7 +85,7 @@ make release
 `make release-dist` compiles all Rust executables in one Cargo invocation,
 builds the generated client, Configurator, and web UI, and produces `dist/`.
 The demo build is packaged as a target-independent static archive whose files
-are served under `/app/` with an `index.html` fallback; it is not included in
+are served under `/demo/` with an `index.html` fallback; it is not included in
 the Platform image.
 The same root lockfile deterministically stages platform and Platform workers runtime
 payloads. `make release-images` copies those prebuilt files into the `runtime`,

--- a/platform/README.md
+++ b/platform/README.md
@@ -69,11 +69,11 @@ entry, which installs an in-browser backend (a Hono router behind a `fetch`
 shim, seeded from `web/src/demo/fixtures/`) before loading the app. It needs no
 server, no sign-in, and no network — the visitor is a platform admin who owns a
 few pre-populated universes, each showing a different use-case — so it can be
-published as a static site (serve `dist-demo/` under `/app/` with an
+published as a static site (serve `dist-demo/` under `/demo/` with an
 `index.html` fallback for client routes).
 
 ```bash
-./dev.sh demo         # Vite dev server on http://localhost:5175/app/ (alias: npm run demo)
+./dev.sh demo         # Vite dev server on http://localhost:5175/demo/ (alias: npm run demo)
 npm run build:demo    # static site in platform/web/dist-demo/
 ```
 

--- a/platform/web/src/components/user-menu.tsx
+++ b/platform/web/src/components/user-menu.tsx
@@ -114,7 +114,9 @@ export function UserMenu({ user, admin }: { user: SessionUser; admin: boolean })
             <DropdownMenuSeparator />
             <DropdownMenuItem
               onClick={() => {
-                void authClient.signOut().then(() => window.location.assign("/app/login"));
+                void authClient.signOut().then(() =>
+                  window.location.assign(`${import.meta.env.BASE_URL}login`),
+                );
               }}
             >
               <LogOut />

--- a/platform/web/src/demo/banner.ts
+++ b/platform/web/src/demo/banner.ts
@@ -23,7 +23,7 @@ export function mountBanner(): void {
   reset.textContent = "Reset";
   reset.className = "font-semibold underline underline-offset-2 hover:opacity-80";
   reset.addEventListener("click", () => {
-    window.location.assign("/app/");
+    window.location.assign(import.meta.env.BASE_URL);
   });
   const dismiss = document.createElement("button");
   dismiss.type = "button";

--- a/platform/web/src/main.tsx
+++ b/platform/web/src/main.tsx
@@ -12,13 +12,14 @@ const queryClient = new QueryClient({
     queries: { retry: 1, refetchOnWindowFocus: false, staleTime: 30_000 },
   },
 });
+const appBasename = import.meta.env.BASE_URL.replace(/\/$/, "");
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
       <ThemeProvider>
         <TooltipProvider>
-          <BrowserRouter basename="/app">
+          <BrowserRouter basename={appBasename}>
             <App />
           </BrowserRouter>
         </TooltipProvider>

--- a/platform/web/src/pages/LoginPage.tsx
+++ b/platform/web/src/pages/LoginPage.tsx
@@ -27,7 +27,7 @@ export function LoginPage() {
       setBusy(false);
       return;
     }
-    window.location.assign("/app/");
+    window.location.assign(import.meta.env.BASE_URL);
   };
 
   return (

--- a/platform/web/src/vite-env.d.ts
+++ b/platform/web/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/platform/web/vite.config.ts
+++ b/platform/web/vite.config.ts
@@ -13,7 +13,7 @@ import { defineConfig, type Plugin } from "vite";
 export default defineConfig(({ mode }) => {
   const demo = mode === "demo";
   return {
-    base: "/app/",
+    base: demo ? "/demo/" : "/app/",
     plugins: [react(), tailwindcss(), ...(demo ? [demoEntry()] : [])],
     resolve: {
       alias: {

--- a/release/release-manifest.schema.json
+++ b/release/release-manifest.schema.json
@@ -102,7 +102,7 @@
         "file": { "type": "string", "minLength": 1 },
         "url": { "type": ["string", "null"] },
         "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
-        "basePath": { "const": "/app/" }
+        "basePath": { "const": "/demo/" }
       }
     }
   }

--- a/scripts/dev/stack.mjs
+++ b/scripts/dev/stack.mjs
@@ -303,7 +303,7 @@ function createPlan(profile, sourceEnv) {
   // no runtime, no Platform server — just Vite in demo mode.
   if (profile === "demo") {
     ports.push({ name: "demo web", port: 5_175 });
-    readiness.push({ name: "demo web", url: "http://localhost:5175/app/" });
+    readiness.push({ name: "demo web", url: "http://localhost:5175/demo/" });
     processes.push({
       name: "demo",
       command: vite,
@@ -784,7 +784,7 @@ function printRunning(plan) {
     );
   }
   if (plan.profile === "demo") {
-    console.log("  demo web      http://localhost:5175/app/  (in-browser backend, scripted data, no sign-in)");
+    console.log("  demo web      http://localhost:5175/demo/  (in-browser backend, scripted data, no sign-in)");
   }
   if (plan.connectors.length > 0) {
     console.log(`  connectors    ${plan.connectors.join(", ")}`);
@@ -825,7 +825,7 @@ Profiles:
   platform  Infrastructure, Platform API, and web UI against the runtime at
             LIGHTSPEED_API_URL (start one with the runtime profile).
   runtime   Infrastructure and the migrated Rust runtime.
-  demo      Web UI only, on http://localhost:5175/app/, over the in-browser
+  demo      Web UI only, on http://localhost:5175/demo/, over the in-browser
             demo backend (scripted data, no sign-in). No Docker, no runtime.
   infra     Postgres, pgAdmin, MinIO, and Temporal only.`);
 }

--- a/scripts/release/create-manifest.mjs
+++ b/scripts/release/create-manifest.mjs
@@ -81,7 +81,7 @@ const manifest = {
   artifacts: {
     demo: {
       ...artifact("DEMO", "-demo-"),
-      basePath: "/app/",
+      basePath: "/demo/",
     },
   },
   typescriptClient: {

--- a/scripts/release/verify-manifest.mjs
+++ b/scripts/release/verify-manifest.mjs
@@ -75,7 +75,7 @@ for (const [name, artifact] of Object.entries(value.artifacts)) {
     fail(`published artifact ${name} has no immutable OCI URL`);
   }
 }
-if (value.artifacts.demo.basePath !== "/app/") fail("demo artifact must be served under /app/");
+if (value.artifacts.demo.basePath !== "/demo/") fail("demo artifact must be served under /demo/");
 if (value.typescriptClient.name !== "@lightspeed/agent-client") fail("unexpected client package");
 if (!/^[0-9a-f]{64}$/.test(value.typescriptClient.sha256)) fail("invalid client checksum");
 if (value.typescriptClient.version !== value.version) fail("client version mismatch");


### PR DESCRIPTION
## Summary

- move the demo build base path and router basename from `/app/` to `/demo/`
- keep the production application at `/app/`
- update demo redirects, release metadata, tests, and documentation accordingly

## Validation

- 92 tests
- workspace typechecks
- production and demo builds
- demo SPA deep-route preview
- development configuration checks