### PR TITLE
Record LLM and tool execution durations

### DIFF
--- a/clients/typescript/schema/api.schema.json
+++ b/clients/typescript/schema/api.schema.json
@@ -15437,6 +15437,15 @@
         "callId": {
           "type": "string"
         },
+        "completedAtMs": {
+          "description": "When the call's terminal result was committed. The window to\n`startedAtMs` includes runtime scheduling overhead.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
         "display": {
           "anyOf": [
             {
@@ -15445,6 +15454,15 @@
             {
               "type": "null"
             }
+          ]
+        },
+        "durationMs": {
+          "description": "Execution milliseconds measured by the runtime around the call body;\nthe remainder of the started/completed window is overhead.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
           ]
         },
         "effects": {
@@ -15460,6 +15478,15 @@
         "output": {
           "type": [
             "string",
+            "null"
+          ]
+        },
+        "startedAtMs": {
+          "description": "When the call was dispatched for execution, from the committed\n`toolCallStarted` event. Absent until dispatch.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": [
+            "integer",
             "null"
           ]
         },

--- a/clients/typescript/src/generated/types.ts
+++ b/clients/typescript/src/generated/types.ts
@@ -2391,10 +2391,25 @@ export interface ToolCallView {
   arguments?: string | null;
   argumentsRef: string;
   callId: string;
+  /**
+   * When the call's terminal result was committed. The window to
+   * `startedAtMs` includes runtime scheduling overhead.
+   */
+  completedAtMs?: number | null;
   display?: ToolCallDisplayView | null;
+  /**
+   * Execution milliseconds measured by the runtime around the call body;
+   * the remainder of the started/completed window is overhead.
+   */
+  durationMs?: number | null;
   effects?: ToolEffectView[];
   isError?: boolean;
   output?: string | null;
+  /**
+   * When the call was dispatched for execution, from the committed
+   * `toolCallStarted` event. Absent until dispatch.
+   */
+  startedAtMs?: number | null;
   status: ToolItemStatus;
   toolName: string;
 }

--- a/crates/api-projection/src/lib.rs
+++ b/crates/api-projection/src/lib.rs
@@ -1041,6 +1041,9 @@ impl<'a> CoreAgentProjector<'a> {
                                 .cloned()
                                 .unwrap_or_default(),
                             display: tool_call_display(call.tool_name.as_str(), &arguments),
+                            started_at_ms: None,
+                            completed_at_ms: None,
+                            duration_ms: None,
                         })
                     }))
                     .await?;
@@ -1050,6 +1053,26 @@ impl<'a> CoreAgentProjector<'a> {
                         status: ToolItemStatus::Running,
                         calls: projected_calls,
                     });
+                }
+                ToolEvent::CallStarted {
+                    run_id: event_run_id,
+                    batch_id,
+                    call_id,
+                    ..
+                } if *event_run_id == run_id => {
+                    let batch_id = api_tool_batch_id(*batch_id);
+                    if let Some(call) = batches
+                        .iter_mut()
+                        .find(|batch| batch.id == batch_id)
+                        .and_then(|batch| {
+                            batch
+                                .calls
+                                .iter_mut()
+                                .find(|call| call.call_id == call_id.as_str())
+                        })
+                    {
+                        call.started_at_ms = Some(entry.observed_at_ms);
+                    }
                 }
                 // The durable per-call completion carries the engine's call
                 // status; it distinguishes `cancelled` from `failed`, which
@@ -1073,6 +1096,8 @@ impl<'a> CoreAgentProjector<'a> {
                     {
                         call.status = core_tool_status_to_api_status(result.status);
                         call.is_error = result.status.is_error();
+                        call.completed_at_ms = Some(entry.observed_at_ms);
+                        call.duration_ms = result.duration_ms;
                     }
                 }
                 ToolEvent::BatchCompleted {
@@ -2475,6 +2500,9 @@ mod tests {
             status,
             effects: Vec::new(),
             display: None,
+            started_at_ms: None,
+            completed_at_ms: None,
+            duration_ms: None,
         }
     }
 
@@ -2917,6 +2945,7 @@ mod tests {
                 turn_id: TurnId::new(3),
                 batch_id: ToolBatchId::new(4),
                 result: engine::ToolCallResult {
+                    duration_ms: None,
                     call_id: engine::ToolCallId::new("call-5"),
                     status: engine::ToolCallStatus::Succeeded,
                     output_ref: None,

--- a/crates/api/contract/api.schema.json
+++ b/crates/api/contract/api.schema.json
@@ -15437,6 +15437,15 @@
         "callId": {
           "type": "string"
         },
+        "completedAtMs": {
+          "description": "When the call's terminal result was committed. The window to\n`startedAtMs` includes runtime scheduling overhead.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
         "display": {
           "anyOf": [
             {
@@ -15445,6 +15454,15 @@
             {
               "type": "null"
             }
+          ]
+        },
+        "durationMs": {
+          "description": "Execution milliseconds measured by the runtime around the call body;\nthe remainder of the started/completed window is overhead.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
           ]
         },
         "effects": {
@@ -15460,6 +15478,15 @@
         "output": {
           "type": [
             "string",
+            "null"
+          ]
+        },
+        "startedAtMs": {
+          "description": "When the call was dispatched for execution, from the committed\n`toolCallStarted` event. Absent until dispatch.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": [
+            "integer",
             "null"
           ]
         },

--- a/crates/api/contract/openrpc.json
+++ b/crates/api/contract/openrpc.json
@@ -15437,6 +15437,15 @@
           "callId": {
             "type": "string"
           },
+          "completedAtMs": {
+            "description": "When the call's terminal result was committed. The window to\n`startedAtMs` includes runtime scheduling overhead.",
+            "format": "uint64",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
           "display": {
             "anyOf": [
               {
@@ -15445,6 +15454,15 @@
               {
                 "type": "null"
               }
+            ]
+          },
+          "durationMs": {
+            "description": "Execution milliseconds measured by the runtime around the call body;\nthe remainder of the started/completed window is overhead.",
+            "format": "uint64",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
             ]
           },
           "effects": {
@@ -15460,6 +15478,15 @@
           "output": {
             "type": [
               "string",
+              "null"
+            ]
+          },
+          "startedAtMs": {
+            "description": "When the call was dispatched for execution, from the committed\n`toolCallStarted` event. Absent until dispatch.",
+            "format": "uint64",
+            "minimum": 0,
+            "type": [
+              "integer",
               "null"
             ]
           },

--- a/crates/api/src/tests.rs
+++ b/crates/api/src/tests.rs
@@ -1627,6 +1627,9 @@ fn run_view_can_expose_tool_batches() {
             turn_id: "turn_1".to_owned(),
             status: ToolItemStatus::Succeeded,
             calls: vec![ToolCallView {
+                started_at_ms: None,
+                completed_at_ms: None,
+                duration_ms: None,
                 call_id: "call_1".to_owned(),
                 tool_name: "read_file".to_owned(),
                 arguments_ref: "sha256:args".to_owned(),

--- a/crates/api/src/views.rs
+++ b/crates/api/src/views.rs
@@ -211,6 +211,18 @@ pub struct ToolCallView {
     pub effects: Vec<ToolEffectView>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub display: Option<ToolCallDisplayView>,
+    /// When the call was dispatched for execution, from the committed
+    /// `toolCallStarted` event. Absent until dispatch.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub started_at_ms: Option<u64>,
+    /// When the call's terminal result was committed. The window to
+    /// `startedAtMs` includes runtime scheduling overhead.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completed_at_ms: Option<u64>,
+    /// Execution milliseconds measured by the runtime around the call body;
+    /// the remainder of the started/completed window is overhead.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]

--- a/crates/cli/src/chat/driver.rs
+++ b/crates/cli/src/chat/driver.rs
@@ -1884,6 +1884,9 @@ mod tests {
                 turn_id: "turn_1".into(),
                 status: ToolItemStatus::Succeeded,
                 calls: vec![ToolCallView {
+                    started_at_ms: None,
+                    completed_at_ms: None,
+                    duration_ms: None,
                     call_id: "call_1".into(),
                     tool_name: "read_file".into(),
                     arguments_ref: "sha256:args".into(),

--- a/crates/engine/src/core/components/tooling.rs
+++ b/crates/engine/src/core/components/tooling.rs
@@ -765,6 +765,12 @@ pub struct ToolCallResult {
     pub error_ref: Option<BlobRef>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub effects: Vec<ToolEffect>,
+    /// Wall-clock milliseconds the executing runtime spent on this call,
+    /// measured around the execution activity. Absent for synthetic results
+    /// (cancelled, unavailable) and executors that do not measure. Recorded
+    /// telemetry only — planning never branches on it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
 }
 
 pub(crate) fn tool_result_context_item_exists(
@@ -1522,6 +1528,7 @@ fn cancelled_tool_result(call: &ObservedToolCall) -> ToolCallResult {
         }],
         error_ref: Some(error_ref),
         effects: Vec::new(),
+        duration_ms: None,
     }
 }
 
@@ -1546,6 +1553,7 @@ fn unavailable_tool_result(call: &ObservedToolCall) -> ToolCallResult {
         }],
         error_ref: Some(error_ref),
         effects: Vec::new(),
+        duration_ms: None,
     }
 }
 

--- a/crates/engine/src/core/components/turn.rs
+++ b/crates/engine/src/core/components/turn.rs
@@ -224,6 +224,11 @@ pub struct LlmGenerationFacts {
     pub provider_response_id: Option<String>,
     pub finish: LlmFinish,
     pub usage: Option<LlmUsage>,
+    /// Wall-clock milliseconds the executing runtime spent on this
+    /// generation (provider round-trip measured around the client call).
+    /// Recorded telemetry only — planning never branches on it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
     pub tool_calls: Vec<ObservedToolCall>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub approval_requests: Vec<ObservedApprovalRequest>,

--- a/crates/engine/src/core/components/workflow_tool.rs
+++ b/crates/engine/src/core/components/workflow_tool.rs
@@ -2900,6 +2900,7 @@ mod tests {
                     failure_ref: None,
                     context_entries: Vec::new(),
                     facts: LlmGenerationFacts {
+                        duration_ms: None,
                         provider_response_id: Some("response-tool".to_owned()),
                         finish: LlmFinish::ToolCalls,
                         usage: None,
@@ -2959,6 +2960,7 @@ mod tests {
         let results = invocations
             .iter()
             .map(|invocation| ToolInvocationResult {
+                duration_ms: None,
                 call_id: invocation.tool_call_id.clone(),
                 status: ToolCallStatus::Succeeded,
                 output_ref: Some(BlobRef::from_bytes(b"accepted")),

--- a/crates/engine/src/core/drive.rs
+++ b/crates/engine/src/core/drive.rs
@@ -1294,6 +1294,7 @@ fn await_resume_result(
         turn_id: batch.turn_id,
         batch_id: batch.batch_id,
         results: vec![ToolInvocationResult {
+            duration_ms: None,
             call_id: call_id.clone(),
             status: ToolCallStatus::Succeeded,
             output_ref: Some(result_ref),
@@ -1390,6 +1391,7 @@ fn joined_workflow_resume_result(
             PromiseStatus::Pending => unreachable!("terminality was checked above"),
         };
         results.push(ToolInvocationResult {
+            duration_ms: None,
             call_id: joined.call_id.clone(),
             status,
             output_ref,
@@ -1452,6 +1454,7 @@ fn validate_minted_promise_id(
 fn invalid_await_tool_result(call_id: ToolCallId, _message: String) -> ToolInvocationResult {
     let error_ref = crate::unavailable_tool_result_ref();
     ToolInvocationResult {
+        duration_ms: None,
         call_id: call_id.clone(),
         status: ToolCallStatus::Failed,
         output_ref: None,
@@ -1918,6 +1921,7 @@ fn invocation_result_to_call_result(result: ToolInvocationResult) -> ToolCallRes
         model_visible_context_entries: result.model_visible_context_entries,
         error_ref: result.error_ref,
         effects: result.effects,
+        duration_ms: result.duration_ms,
     }
 }
 
@@ -2227,6 +2231,7 @@ mod tests {
                     failure_ref: None,
                     context_entries: Vec::new(),
                     facts: LlmGenerationFacts {
+                        duration_ms: None,
                         provider_response_id: Some("resp-tool".to_owned()),
                         finish: LlmFinish::ToolCalls,
                         usage: None,
@@ -2313,6 +2318,7 @@ mod tests {
             turn_id: request.turn_id,
             batch_id: request.batch_id,
             results: vec![ToolInvocationResult {
+                duration_ms: None,
                 call_id: request.calls[0].call_id.clone(),
                 status: ToolCallStatus::Succeeded,
                 output_ref: Some(BlobRef::from_bytes(b"wait completed")),
@@ -3507,6 +3513,7 @@ mod tests {
                         ),
                     ],
                     facts: LlmGenerationFacts {
+                        duration_ms: None,
                         provider_response_id: Some("resp-1".to_owned()),
                         finish: LlmFinish::Stop,
                         usage: None,
@@ -4202,6 +4209,7 @@ mod tests {
                 failure_ref: None,
                 context_entries: Vec::new(),
                 facts: LlmGenerationFacts {
+                    duration_ms: None,
                     provider_response_id: Some("resp-late".to_owned()),
                     finish: LlmFinish::Stop,
                     usage: None,
@@ -4289,6 +4297,7 @@ mod tests {
                     failure_ref: None,
                     context_entries: Vec::new(),
                     facts: LlmGenerationFacts {
+                        duration_ms: None,
                         provider_response_id: Some("resp-tool".to_owned()),
                         finish: LlmFinish::ToolCalls,
                         usage: None,
@@ -4377,6 +4386,7 @@ mod tests {
                 token_estimate: None,
             }],
             facts: LlmGenerationFacts {
+                duration_ms: None,
                 provider_response_id: None,
                 finish: LlmFinish::Stop,
                 usage: None,
@@ -4802,6 +4812,7 @@ mod tests {
                     failure_ref: None,
                     context_entries: Vec::new(),
                     facts: LlmGenerationFacts {
+                        duration_ms: None,
                         provider_response_id: Some("resp-1".to_owned()),
                         finish: LlmFinish::Stop,
                         usage: None,
@@ -4941,6 +4952,7 @@ mod tests {
                         token_estimate: None,
                     }],
                     facts: LlmGenerationFacts {
+                        duration_ms: None,
                         provider_response_id: Some("resp-1".to_owned()),
                         finish: LlmFinish::Stop,
                         usage: None,
@@ -5007,6 +5019,7 @@ mod tests {
                         partial_ref.clone(),
                     )],
                     facts: LlmGenerationFacts {
+                        duration_ms: None,
                         provider_response_id: Some("msg_cut".to_owned()),
                         finish: LlmFinish::Length,
                         usage: None,
@@ -5084,6 +5097,7 @@ mod tests {
                     failure_ref: Some(failure_ref.clone()),
                     context_entries: Vec::new(),
                     facts: LlmGenerationFacts {
+                        duration_ms: None,
                         provider_response_id: Some("msg_refused".to_owned()),
                         finish: LlmFinish::ContentFilter,
                         usage: None,
@@ -5152,6 +5166,7 @@ mod tests {
                     failure_ref: Some(failure_ref.clone()),
                     context_entries: Vec::new(),
                     facts: LlmGenerationFacts {
+                        duration_ms: None,
                         provider_response_id: None,
                         finish: LlmFinish::Failed,
                         usage: None,
@@ -5639,6 +5654,7 @@ mod tests {
                     failure_ref: None,
                     context_entries: Vec::new(),
                     facts: LlmGenerationFacts {
+                        duration_ms: None,
                         provider_response_id: Some("resp-1".to_owned()),
                         finish: LlmFinish::Stop,
                         usage: None,
@@ -6173,6 +6189,7 @@ mod tests {
                 turn_id: request.turn_id,
                 batch_id: request.batch_id,
                 results: vec![ToolInvocationResult {
+                    duration_ms: None,
                     call_id: call.call_id.clone(),
                     status: ToolCallStatus::Succeeded,
                     output_ref: None,
@@ -6378,6 +6395,7 @@ mod tests {
             if call.tool_name.as_str() == "local_echo" {
                 let content_ref = BlobRef::from_bytes(b"echo complete");
                 results.push(ToolInvocationResult {
+                    duration_ms: None,
                     call_id: call.call_id.clone(),
                     status: ToolCallStatus::Succeeded,
                     output_ref: Some(content_ref.clone()),
@@ -6424,6 +6442,7 @@ mod tests {
             };
             joined_ids.push((call.call_id.clone(), promise_id));
             results.push(ToolInvocationResult {
+                duration_ms: None,
                 call_id: call.call_id.clone(),
                 status: ToolCallStatus::Succeeded,
                 output_ref: None,
@@ -6633,6 +6652,7 @@ mod tests {
             )])),
         };
         let completed_results = vec![ToolInvocationResult {
+            duration_ms: None,
             call_id: workflow_call.call_id.clone(),
             status: ToolCallStatus::Succeeded,
             output_ref: None,
@@ -7447,6 +7467,7 @@ mod tests {
     ) -> ToolInvocationResult {
         let content_ref = BlobRef::from_bytes(call_id.as_str().as_bytes());
         ToolInvocationResult {
+            duration_ms: None,
             call_id: call_id.clone(),
             status,
             output_ref: (status == ToolCallStatus::Succeeded).then(|| content_ref.clone()),
@@ -7537,6 +7558,56 @@ mod tests {
         assert_eq!(completed.results[0].status, ToolCallStatus::Succeeded);
         assert_eq!(completed.results[1].status, ToolCallStatus::Failed);
         assert_ne!(active_run.active_tool_batch_id, Some(request.batch_id));
+    }
+
+    /// Runtime-measured per-call durations recorded by the execution
+    /// activity survive on the stored tool results, where analytics and
+    /// projections read them back per call.
+    #[test]
+    fn per_call_results_retain_runtime_durations() {
+        let session_id = SessionId::new("session-durations");
+        let mut drive = CoreAgentDrive::from_replayed(session_id, CoreAgentState::new(), None);
+        let request = two_call_tool_batch(&mut drive, config());
+
+        let mut first = per_call_result(
+            &request.calls[0].call_id,
+            ToolCallStatus::Succeeded,
+            Vec::new(),
+        );
+        first.duration_ms = Some(400);
+        let first = drive
+            .resume_tool_call(request.batch_id, first, 121)
+            .expect("resume first call");
+        commit_action(&mut drive, first);
+
+        let mut second = per_call_result(
+            &request.calls[1].call_id,
+            ToolCallStatus::Succeeded,
+            Vec::new(),
+        );
+        second.duration_ms = Some(600);
+        let second = drive
+            .resume_tool_call(request.batch_id, second, 122)
+            .expect("resume second call");
+        commit_action(&mut drive, second);
+
+        loop {
+            let action = drive.next_action(140, 64).expect("next action");
+            if matches!(
+                action,
+                CoreAgentAction::GenerateLlm { .. } | CoreAgentAction::Idle
+            ) {
+                break;
+            }
+            commit_action(&mut drive, action);
+        }
+        let active_run = drive.state().runs.active.as_ref().expect("active run");
+        let completed_batch = active_run
+            .completed_tool_batches
+            .get(&request.batch_id)
+            .expect("completed batch");
+        assert_eq!(completed_batch.results[0].duration_ms, Some(400));
+        assert_eq!(completed_batch.results[1].duration_ms, Some(600));
     }
 
     #[test]

--- a/crates/engine/src/core/io.rs
+++ b/crates/engine/src/core/io.rs
@@ -489,6 +489,11 @@ pub struct ToolInvocationResult {
     pub error_ref: Option<BlobRef>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub effects: Vec<ToolEffect>,
+    /// Wall-clock milliseconds the executing runtime spent on this call.
+    /// Stamped by the execution activity; carried into the durable
+    /// `ToolCallResult` unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
 }
 
 impl ToolInvocationResult {
@@ -609,6 +614,7 @@ mod tests {
                 .calls
                 .iter()
                 .map(|call| ToolInvocationResult {
+                    duration_ms: None,
                     call_id: call.call_id.clone(),
                     status: ToolCallStatus::Succeeded,
                     output_ref: Some(call.arguments_ref.clone()),

--- a/crates/llm-runtime/src/anthropic_messages.rs
+++ b/crates/llm-runtime/src/anthropic_messages.rs
@@ -1143,6 +1143,7 @@ pub async fn result_from_response(
         failure_ref,
         context_entries,
         facts: LlmGenerationFacts {
+            duration_ms: None,
             provider_response_id: Some(response.parsed.id.clone()),
             finish,
             usage,
@@ -1187,6 +1188,7 @@ async fn refused_generation_result(
         failure_ref: Some(failure_ref),
         context_entries: Vec::new(),
         facts: LlmGenerationFacts {
+            duration_ms: None,
             provider_response_id: Some(response.parsed.id.clone()),
             finish: LlmFinish::ContentFilter,
             usage: response.parsed.usage.as_ref().map(llm_usage),

--- a/crates/llm-runtime/src/openai_completions.rs
+++ b/crates/llm-runtime/src/openai_completions.rs
@@ -1121,6 +1121,7 @@ pub async fn result_from_response(
         failure_ref,
         context_entries,
         facts: LlmGenerationFacts {
+            duration_ms: None,
             provider_response_id: Some(response.parsed.id.clone()),
             finish,
             usage,

--- a/crates/llm-runtime/src/openai_responses.rs
+++ b/crates/llm-runtime/src/openai_responses.rs
@@ -938,6 +938,7 @@ pub async fn result_from_response(
         failure_ref,
         context_entries,
         facts: LlmGenerationFacts {
+            duration_ms: None,
             provider_response_id: Some(response.parsed.id.clone()),
             finish,
             usage,

--- a/crates/llm-runtime/src/result.rs
+++ b/crates/llm-runtime/src/result.rs
@@ -17,6 +17,7 @@ pub fn failed_generation_result(run_id: RunId, turn_id: TurnId) -> LlmGeneration
         failure_ref: None,
         context_entries: Vec::new(),
         facts: LlmGenerationFacts {
+            duration_ms: None,
             provider_response_id: None,
             finish: LlmFinish::Failed,
             usage: None,

--- a/crates/temporal-server/src/worker/activities/common.rs
+++ b/crates/temporal-server/src/worker/activities/common.rs
@@ -115,6 +115,7 @@ pub(super) async fn failed_generation_result_from_error(
         failure_ref: Some(failure_ref),
         context_entries: Vec::new(),
         facts: LlmGenerationFacts {
+            duration_ms: None,
             provider_response_id: None,
             finish: LlmFinish::Failed,
             usage: None,
@@ -173,6 +174,7 @@ pub(super) async fn failed_tool_batch_result(
         )
         .await?;
         results.push(ToolInvocationResult {
+            duration_ms: None,
             call_id: call.call_id.clone(),
             status: ToolCallStatus::Failed,
             output_ref: None,
@@ -212,6 +214,7 @@ pub(super) async fn failed_tool_call_result(
     )
     .await?;
     Ok(ToolInvocationResult {
+        duration_ms: None,
         call_id: request.call.call_id.clone(),
         status: ToolCallStatus::Failed,
         output_ref: None,

--- a/crates/temporal-server/src/worker/activities/llm.rs
+++ b/crates/temporal-server/src/worker/activities/llm.rs
@@ -20,8 +20,10 @@ pub(super) async fn generate(
 ) -> Result<LlmGenerationResult, ActivityError> {
     let request = request.request;
     let session_id = request.session_id.clone();
+    let started = std::time::Instant::now();
     match deps.llm.generate(request.clone()).await {
-        Ok(result) => {
+        Ok(mut result) => {
+            result.facts.duration_ms = Some(elapsed_ms(started));
             if let Some(usage) = result.facts.usage.as_ref() {
                 observe_prompt_cache(&session_id, usage);
             }
@@ -42,8 +44,16 @@ pub(super) async fn generate(
         // result and are never retried.
         Err(error) => failed_generation_result_from_error(deps.blobs.as_ref(), request, error)
             .await
+            .map(|mut result| {
+                result.facts.duration_ms = Some(elapsed_ms(started));
+                result
+            })
             .map_err(activity_error),
     }
+}
+
+fn elapsed_ms(started: std::time::Instant) -> u64 {
+    u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX)
 }
 
 /// Prompts at least this long are expected to hit the provider cache once

--- a/crates/temporal-server/src/worker/activities/storage.rs
+++ b/crates/temporal-server/src/worker/activities/storage.rs
@@ -593,6 +593,7 @@ mod tests {
                 failure_ref: None,
                 context_entries: Vec::new(),
                 facts: LlmGenerationFacts {
+                    duration_ms: None,
                     provider_response_id: Some(format!("tool-response-{}", request.turn_id)),
                     finish: if first {
                         LlmFinish::ToolCalls
@@ -656,6 +657,7 @@ mod tests {
                         completion_promises: None,
                     };
                     ToolInvocationResult {
+                        duration_ms: None,
                         call_id: call.call_id.clone(),
                         status: ToolCallStatus::Succeeded,
                         output_ref: Some(BlobRef::from_bytes(b"accepted")),

--- a/crates/temporal-server/src/worker/activities/tools.rs
+++ b/crates/temporal-server/src/worker/activities/tools.rs
@@ -149,6 +149,7 @@ pub(super) async fn invoke_call(
                         ToolCallStatus::Succeeded
                     };
                     Ok(ToolCallExecution::Completed(ToolInvocationResult {
+                        duration_ms: None,
                         call_id: request.call.call_id.clone(),
                         status,
                         output_ref: Some(output_ref),
@@ -175,9 +176,16 @@ pub(super) async fn invoke_call(
                 .map(ToolCallExecution::Completed),
         }
     };
+    let started = std::time::Instant::now();
+    let stamp = |mut result: ToolInvocationResult| {
+        result.duration_ms = Some(u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX));
+        result
+    };
     match tokio::time::timeout(deadline, execution).await {
         Ok(Ok(ToolCallExecution::Completed(result))) => {
-            Ok(ToolInvokeCallActivityResult::Completed { result })
+            Ok(ToolInvokeCallActivityResult::Completed {
+                result: stamp(result),
+            })
         }
         Ok(Ok(ToolCallExecution::EnvironmentNotReady { environment_id, .. })) => {
             Ok(ToolInvokeCallActivityResult::EnvironmentNotReady { environment_id })
@@ -188,7 +196,9 @@ pub(super) async fn invoke_call(
         Ok(Err(error)) => {
             super::common::failed_tool_call_result(deps.blobs.as_ref(), &request, error.to_string())
                 .await
-                .map(|result| ToolInvokeCallActivityResult::Completed { result })
+                .map(|result| ToolInvokeCallActivityResult::Completed {
+                    result: stamp(result),
+                })
                 .map_err(activity_error)
         }
         Err(_elapsed) => super::common::failed_tool_call_result(
@@ -200,7 +210,9 @@ pub(super) async fn invoke_call(
             ),
         )
         .await
-        .map(|result| ToolInvokeCallActivityResult::Completed { result })
+        .map(|result| ToolInvokeCallActivityResult::Completed {
+            result: stamp(result),
+        })
         .map_err(activity_error),
     }
 }

--- a/crates/temporal-server/src/worker/fake.rs
+++ b/crates/temporal-server/src/worker/fake.rs
@@ -250,6 +250,7 @@ impl FakeLlm {
             failure_ref: None,
             context_entries,
             facts: LlmGenerationFacts {
+                duration_ms: None,
                 provider_response_id: Some(format!("fake-tool-{}", request.turn_id.as_u64())),
                 finish: LlmFinish::ToolCalls,
                 usage: None,
@@ -301,6 +302,7 @@ impl FakeLlm {
                 token_estimate: None,
             }],
             facts: LlmGenerationFacts {
+                duration_ms: None,
                 provider_response_id: Some(format!("fake-final-{}", request.turn_id.as_u64())),
                 finish: LlmFinish::Stop,
                 usage: None,
@@ -414,6 +416,7 @@ impl CoreAgentTools for FakeTools {
                     .await
                     .map_err(io_error)?;
                 results.push(ToolInvocationResult {
+                    duration_ms: None,
                     call_id: call.call_id.clone(),
                     status: ToolCallStatus::Failed,
                     output_ref: None,
@@ -436,6 +439,7 @@ impl CoreAgentTools for FakeTools {
                 .await
                 .map_err(io_error)?;
             results.push(ToolInvocationResult {
+                duration_ms: None,
                 call_id: call.call_id.clone(),
                 status: ToolCallStatus::Succeeded,
                 output_ref: Some(output_ref.clone()),

--- a/crates/temporal-server/src/worker/session_tools.rs
+++ b/crates/temporal-server/src/worker/session_tools.rs
@@ -730,6 +730,7 @@ impl SessionTools {
             .await
             .map_err(map_blob_error)?;
         Ok(ToolInvocationResult {
+            duration_ms: None,
             call_id: call.call_id.clone(),
             status: ToolCallStatus::Succeeded,
             output_ref: Some(output_ref),
@@ -774,6 +775,7 @@ impl SessionTools {
                 .map_err(map_blob_error)?;
         }
         Ok(ToolInvocationResult {
+            duration_ms: None,
             call_id: call.call_id.clone(),
             status: ToolCallStatus::Succeeded,
             output_ref: Some(output_ref.clone()),
@@ -1806,6 +1808,7 @@ async fn failed_result_bytes(
 ) -> Result<ToolInvocationResult, CoreAgentIoError> {
     let error_ref = blobs.put_bytes(bytes).await.map_err(map_blob_error)?;
     Ok(ToolInvocationResult {
+        duration_ms: None,
         call_id: call_id.clone(),
         status: ToolCallStatus::Failed,
         output_ref: None,

--- a/crates/temporal-server/tests/mcp_live.rs
+++ b/crates/temporal-server/tests/mcp_live.rs
@@ -249,6 +249,7 @@ impl MatrixScriptedLlm {
                 token_estimate: None,
             }],
             facts: LlmGenerationFacts {
+                duration_ms: None,
                 provider_response_id: Some(format!("mcp-matrix-{}", request.turn_id.as_u64())),
                 finish: LlmFinish::ToolCalls,
                 usage: None,
@@ -292,6 +293,7 @@ impl MatrixScriptedLlm {
                 token_estimate: None,
             }],
             facts: LlmGenerationFacts {
+                duration_ms: None,
                 provider_response_id: Some(format!(
                     "mcp-matrix-final-{}",
                     request.turn_id.as_u64()
@@ -955,6 +957,7 @@ impl NativeMcpScriptedLlm {
                 token_estimate: None,
             }],
             facts: LlmGenerationFacts {
+                duration_ms: None,
                 provider_response_id: Some(format!("native-mcp-{}", request.turn_id.as_u64())),
                 finish: LlmFinish::ToolCalls,
                 usage: None,
@@ -998,6 +1001,7 @@ impl NativeMcpScriptedLlm {
                 token_estimate: None,
             }],
             facts: LlmGenerationFacts {
+                duration_ms: None,
                 provider_response_id: Some(format!(
                     "native-mcp-final-{}",
                     request.turn_id.as_u64()
@@ -1062,6 +1066,7 @@ impl CoreAgentLlm for ApprovalScriptedLlm {
                     token_estimate: None,
                 }],
                 facts: LlmGenerationFacts {
+                    duration_ms: None,
                     provider_response_id: Some(format!(
                         "approval-final-{}-{}",
                         request.run_id.as_u64(),
@@ -1114,6 +1119,7 @@ impl CoreAgentLlm for ApprovalScriptedLlm {
                 token_estimate: None,
             }],
             facts: LlmGenerationFacts {
+                duration_ms: None,
                 provider_response_id: Some(format!("approval-request-{}", request.run_id.as_u64())),
                 finish: LlmFinish::Stop,
                 usage: None,

--- a/crates/temporal-server/tests/subagents_live.rs
+++ b/crates/temporal-server/tests/subagents_live.rs
@@ -196,6 +196,7 @@ impl SubagentScriptedLlm {
             failure_ref: None,
             context_entries,
             facts: LlmGenerationFacts {
+                duration_ms: None,
                 provider_response_id: Some(format!("subagent-tools-{}", request.turn_id.as_u64())),
                 finish: LlmFinish::ToolCalls,
                 usage: None,
@@ -233,6 +234,7 @@ impl SubagentScriptedLlm {
                 token_estimate: None,
             }],
             facts: LlmGenerationFacts {
+                duration_ms: None,
                 provider_response_id: Some(format!("subagent-final-{}", request.turn_id.as_u64())),
                 finish: LlmFinish::Stop,
                 usage: None,

--- a/crates/temporal-server/tests/workflow_tool_plugins_live.rs
+++ b/crates/temporal-server/tests/workflow_tool_plugins_live.rs
@@ -550,6 +550,7 @@ impl WorkflowToolScriptedLlm {
                 token_estimate: None,
             }],
             facts: LlmGenerationFacts {
+                duration_ms: None,
                 provider_response_id: Some(format!(
                     "workflow-tool-{}-{}",
                     tool_name,
@@ -597,6 +598,7 @@ impl WorkflowToolScriptedLlm {
                 token_estimate: None,
             }],
             facts: LlmGenerationFacts {
+                duration_ms: None,
                 provider_response_id: Some(format!(
                     "workflow-tool-final-{}",
                     request.turn_id.as_u64()

--- a/crates/temporal-workflow/src/workflows/session/activity_calls.rs
+++ b/crates/temporal-workflow/src/workflows/session/activity_calls.rs
@@ -54,6 +54,7 @@ pub(super) async fn call_llm_generate(
                     failure_ref: Some(failure_ref),
                     context_entries: Vec::new(),
                     facts: engine::LlmGenerationFacts {
+                        duration_ms: None,
                         provider_response_id: None,
                         finish: engine::LlmFinish::Failed,
                         usage: None,

--- a/crates/temporal-workflow/src/workflows/session/tool_batches.rs
+++ b/crates/temporal-workflow/src/workflows/session/tool_batches.rs
@@ -497,6 +497,7 @@ fn boundary_call_result(
     error_ref: BlobRef,
 ) -> ToolInvocationResult {
     ToolInvocationResult {
+        duration_ms: None,
         call_id: call_id.clone(),
         status,
         output_ref: None,

--- a/crates/test-support/src/runner/drive.rs
+++ b/crates/test-support/src/runner/drive.rs
@@ -736,6 +736,7 @@ async fn failed_generation_result_from_error(
         failure_ref: Some(failure_ref),
         context_entries: Vec::new(),
         facts: LlmGenerationFacts {
+            duration_ms: None,
             provider_response_id: None,
             finish: LlmFinish::Failed,
             usage: None,
@@ -794,6 +795,7 @@ async fn failed_tool_batch_result(
         )
         .await?;
         results.push(ToolInvocationResult {
+            duration_ms: None,
             call_id: call.call_id.clone(),
             status: ToolCallStatus::Failed,
             output_ref: None,
@@ -1044,6 +1046,7 @@ mod tests {
                     failure_ref: None,
                     context_entries: Vec::new(),
                     facts: LlmGenerationFacts {
+                        duration_ms: None,
                         provider_response_id: Some("resp-tool".to_owned()),
                         finish: LlmFinish::ToolCalls,
                         usage: None,
@@ -1098,6 +1101,7 @@ mod tests {
                     failure_ref: None,
                     context_entries: Vec::new(),
                     facts: LlmGenerationFacts {
+                        duration_ms: None,
                         provider_response_id: Some("resp-read-skill".to_owned()),
                         finish: LlmFinish::ToolCalls,
                         usage: None,
@@ -1149,6 +1153,7 @@ mod tests {
                 token_estimate: None,
             }],
             facts: LlmGenerationFacts {
+                duration_ms: None,
                 provider_response_id: Some("resp-1".to_owned()),
                 finish: LlmFinish::Stop,
                 usage: None,
@@ -2358,6 +2363,7 @@ mod tests {
                 &entry.event,
                 CoreAgentEvent::Tool(engine::ToolEvent::CallCompleted {
                     result: ToolCallResult {
+                        duration_ms: None,
                         status: ToolCallStatus::Failed,
                         error_ref: Some(_),
                         ..

--- a/crates/tools/src/runtime/inline.rs
+++ b/crates/tools/src/runtime/inline.rs
@@ -198,6 +198,7 @@ impl InlineToolRuntime {
         effects.extend(ctx.drain_tool_effects());
 
         Ok(ToolInvocationResult {
+            duration_ms: None,
             call_id: call.call_id.clone(),
             status: ToolCallStatus::Succeeded,
             output_ref: Some(output_ref),
@@ -229,6 +230,7 @@ impl InlineToolRuntime {
             .await?;
 
         Ok(ToolInvocationResult {
+            duration_ms: None,
             call_id: call.call_id.clone(),
             status: ToolCallStatus::Failed,
             output_ref: None,
@@ -258,6 +260,7 @@ impl InlineToolRuntime {
             .await?;
 
         Ok(ToolInvocationResult {
+            duration_ms: None,
             call_id: call.call_id.clone(),
             status: ToolCallStatus::Succeeded,
             output_ref: Some(output_ref),
@@ -284,6 +287,7 @@ impl InlineToolRuntime {
             .await?;
 
         Ok(ToolInvocationResult {
+            duration_ms: None,
             call_id: call.call_id.clone(),
             status: ToolCallStatus::Failed,
             output_ref: None,


### PR DESCRIPTION
## Summary

- measure LLM provider round-trip and individual tool execution durations in runtime activities
- persist duration telemetry without allowing deterministic planning to branch on wall-clock data
- expose tool-call start, completion, and execution timing through API projections and generated TypeScript contracts
- update runtime adapters and test fixtures, with regression coverage for retained per-call durations

## Testing

- `cargo fmt --all -- --check`
- `cargo test --locked -p engine per_call_results_retain_runtime_durations`
- `cargo test --locked -p api --test schema_artifacts`