### PR TITLE
Install protoc in tagged release workflow

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -62,6 +62,13 @@ jobs:
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "version=$LIGHTSPEED_PRODUCT_VERSION" >> "$GITHUB_OUTPUT"
           echo "staging_tag=staging-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" >> "$GITHUB_OUTPUT"
+      - name: Install Protocol Buffers compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends \
+            libprotobuf-dev protobuf-compiler
+          test -f /usr/include/google/protobuf/duration.proto
+          echo "PROTOC_INCLUDE=/usr/include" >> "$GITHUB_ENV"
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772
         with:
           toolchain: 1.97.1


### PR DESCRIPTION
## Summary

- install the Protocol Buffers compiler before testing tagged release source
- mirror the setup already used by main Rust CI
- export `PROTOC_INCLUDE` so well-known protobuf types resolve consistently

The first `v0.1.0` release attempt stopped before publication because `prost-wkt-types` could not find `protoc`.

## Validation

- `scripts/release/verify-metadata.sh`
- `git diff --check`