### PR TITLE
Install protoc without sudo in release jobs

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -63,12 +63,15 @@ jobs:
           echo "version=$LIGHTSPEED_PRODUCT_VERSION" >> "$GITHUB_OUTPUT"
           echo "staging_tag=staging-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" >> "$GITHUB_OUTPUT"
       - name: Install Protocol Buffers compiler
+        id: protoc
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        with:
+          version: "29.3"
+      - name: Configure Protocol Buffers includes
         run: |
-          sudo apt-get update
-          sudo apt-get install --yes --no-install-recommends \
-            libprotobuf-dev protobuf-compiler
-          test -f /usr/include/google/protobuf/duration.proto
-          echo "PROTOC_INCLUDE=/usr/include" >> "$GITHUB_ENV"
+          protoc --version
+          test -f "${{ steps.protoc.outputs.path }}/include/google/protobuf/duration.proto"
+          echo "PROTOC_INCLUDE=${{ steps.protoc.outputs.path }}/include" >> "$GITHUB_ENV"
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772
         with:
           toolchain: 1.97.1


### PR DESCRIPTION
## Summary

- install an exact protoc version in the Actions tool cache instead of using `sudo apt-get`
- configure `PROTOC_INCLUDE` from the action output
- keep the action pinned to the full v3.0.0 commit

The protected self-hosted release runner does not grant passwordless sudo, so the apt-based setup in #69 could not run.

## Validation

- `scripts/release/verify-metadata.sh`
- `git diff --check`