### PR TITLE
Scale MCP discovery for enterprise inventories

### DIFF
--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -199,16 +199,44 @@ pub struct McpToolDiscoveryLimits {
 impl Default for McpToolDiscoveryLimits {
     fn default() -> Self {
         Self {
-            max_pages: 8,
-            max_tools: 256,
-            max_response_bytes: 2 * 1024 * 1024,
+            // Enterprise MCPs commonly expose broad, paginated inventories.
+            // Keep hard memory/wire bounds, but size the defaults for those
+            // servers rather than for small development fixtures.
+            max_pages: 64,
+            max_tools: 2_048,
+            max_response_bytes: 16 * 1024 * 1024,
+            // Execution results have a separate context-safety envelope;
+            // broadening discovery must not silently admit giant tool output.
             max_tool_call_response_bytes: 2 * 1024 * 1024,
             max_name_bytes: 128,
-            max_text_bytes: 4 * 1024,
-            max_schema_bytes: 64 * 1024,
-            max_schema_depth: 32,
+            max_text_bytes: 16 * 1024,
+            max_schema_bytes: 512 * 1024,
+            max_schema_depth: 64,
         }
     }
+}
+
+/// Truncate untrusted human-facing MCP metadata without splitting UTF-8.
+/// Protocol identity and executable schemas must use validation instead.
+pub fn truncate_utf8_with_ellipsis(mut value: String, max_bytes: usize) -> String {
+    if value.len() <= max_bytes {
+        return value;
+    }
+    const ELLIPSIS: &str = "…";
+    let append_ellipsis = max_bytes >= ELLIPSIS.len();
+    let mut end = if append_ellipsis {
+        max_bytes - ELLIPSIS.len()
+    } else {
+        max_bytes
+    };
+    while !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    value.truncate(end);
+    if append_ellipsis {
+        value.push_str(ELLIPSIS);
+    }
+    value
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -849,6 +877,17 @@ mod tests {
         let record = put_request("echo", McpServerStatus::Active).into_record();
 
         record.validate().expect("valid MCP server record");
+    }
+
+    #[test]
+    fn metadata_truncation_preserves_utf8_and_byte_budget() {
+        let value = format!("prefix-{}-suffix", "雪".repeat(8));
+        let truncated = truncate_utf8_with_ellipsis(value, 17);
+        assert!(truncated.is_char_boundary(truncated.len()));
+        assert!(truncated.len() <= 17);
+        assert!(truncated.ends_with('…'));
+        assert_eq!(truncate_utf8_with_ellipsis("abc".to_owned(), 2), "ab");
+        assert_eq!(truncate_utf8_with_ellipsis("abc".to_owned(), 3), "abc");
     }
 
     #[test]

--- a/crates/temporal-server/src/gateway/service/mcp_api.rs
+++ b/crates/temporal-server/src/gateway/service/mcp_api.rs
@@ -2,6 +2,13 @@ use super::*;
 
 pub(super) const MCP_SERVER_SECRET_NAMESPACE: &str = "mcp_server";
 
+// Discovery is an unpaginated management response today. Preserve every tool
+// name while sharing a bounded amount of optional display text across broad
+// inventories, leaving ample room under the gateway's 2 MiB JSON-RPC budget
+// for names, annotations, and response framing.
+const DISCOVERY_VIEW_TEXT_BUDGET_BYTES: usize = 512 * 1024;
+const DISCOVERY_VIEW_MAX_FIELD_BYTES: usize = 4 * 1024;
+
 pub(super) fn put_mcp_server_record(
     server: McpServerInput,
     now_ms: i64,
@@ -61,13 +68,21 @@ pub(super) fn mcp_server_view(record: mcp::McpServerRecord) -> api::McpServerVie
 pub(super) fn mcp_tool_discovery_success(
     tools: Vec<mcp::DiscoveredMcpTool>,
 ) -> api::McpServerToolsDiscoverResponse {
+    let field_limit = DISCOVERY_VIEW_TEXT_BUDGET_BYTES
+        .checked_div(tools.len().saturating_mul(2).max(1))
+        .unwrap_or(0)
+        .min(DISCOVERY_VIEW_MAX_FIELD_BYTES);
     api::McpServerToolsDiscoverResponse::Success {
         tools: tools
             .into_iter()
             .map(|tool| api::McpAdvertisedToolView {
                 name: tool.name,
-                title: tool.title,
-                description: tool.description,
+                title: tool
+                    .title
+                    .map(|value| mcp::truncate_utf8_with_ellipsis(value, field_limit)),
+                description: tool
+                    .description
+                    .map(|value| mcp::truncate_utf8_with_ellipsis(value, field_limit)),
                 annotations: tool
                     .annotations
                     .map(|annotations| api::McpToolAnnotationsView {
@@ -571,5 +586,40 @@ mod tests {
             panic!("MCP search meta-tool must be a function");
         };
         assert_eq!(function.strict, Some(false));
+    }
+
+    #[test]
+    fn broad_discovery_projection_preserves_names_within_response_budget() {
+        let limits = mcp::McpToolDiscoveryLimits::default();
+        let tools = (0..limits.max_tools)
+            .map(|index| mcp::DiscoveredMcpTool {
+                name: format!("tool_{index:04}_{}", "n".repeat(96)),
+                title: Some("t".repeat(limits.max_text_bytes)),
+                description: Some("d".repeat(limits.max_text_bytes)),
+                input_schema: serde_json::json!({"type": "object"}),
+                annotations: Some(mcp::McpToolAnnotations {
+                    read_only_hint: Some(true),
+                    destructive_hint: Some(false),
+                    idempotent_hint: Some(true),
+                    open_world_hint: Some(false),
+                }),
+            })
+            .collect::<Vec<_>>();
+
+        let response = mcp_tool_discovery_success(tools);
+        let api::McpServerToolsDiscoverResponse::Success { tools } = &response else {
+            panic!("discovery projection must succeed");
+        };
+        assert_eq!(tools.len(), limits.max_tools);
+        assert_eq!(
+            tools.first().unwrap().name,
+            format!("tool_{:04}_{}", 0, "n".repeat(96))
+        );
+        assert!(
+            serde_json::to_vec(&response)
+                .expect("serialize discovery response")
+                .len()
+                < 2 * 1024 * 1024
+        );
     }
 }

--- a/crates/temporal-server/src/gateway/service/mcp_discovery.rs
+++ b/crates/temporal-server/src/gateway/service/mcp_discovery.rs
@@ -587,7 +587,10 @@ impl StreamableHttpClient for BoundedReqwestClient {
 
 impl HttpMcpToolDiscoverer {
     pub(crate) fn new() -> Self {
-        let timeout = Duration::from_secs(10);
+        // One deadline covers DNS, initialization, every tools/list page, and
+        // shutdown. Large remote catalogs need more than the tiny-fixture
+        // budget while still remaining strictly bounded.
+        let timeout = Duration::from_secs(30);
         Self {
             public_http_policy: PinnedHttpPolicy::public_only().with_timeout(timeout),
             private_http_policy: PinnedHttpPolicy::allowing_private_networks()
@@ -860,12 +863,11 @@ fn project_tool(
     limits: McpToolDiscoveryLimits,
 ) -> Result<DiscoveredMcpTool, McpToolDiscoveryFailure> {
     let name = bounded_required_text(tool.name.as_ref(), "tool name", limits.max_name_bytes)?;
-    let direct_title = bounded_optional_text(tool.title, "tool title", limits.max_text_bytes)?;
-    let description = bounded_optional_text(
+    let direct_title = truncated_optional_text(tool.title, limits.max_text_bytes);
+    let description = truncated_optional_text(
         tool.description.map(|value| value.into_owned()),
-        "tool description",
         limits.max_text_bytes,
-    )?;
+    );
 
     let schema = Value::Object(tool.input_schema.as_ref().clone());
     if schema.get("type").and_then(Value::as_str) != Some("object") {
@@ -890,11 +892,7 @@ fn project_tool(
 
     let (annotation_title, annotations) = match tool.annotations {
         Some(annotations) => {
-            let title = bounded_optional_text(
-                annotations.title,
-                "annotation title",
-                limits.max_text_bytes,
-            )?;
+            let title = truncated_optional_text(annotations.title, limits.max_text_bytes);
             (
                 title,
                 Some(McpToolAnnotations {
@@ -937,18 +935,12 @@ fn bounded_required_text(
     Ok(value.to_owned())
 }
 
-fn bounded_optional_text(
-    value: Option<String>,
-    field: &str,
-    max_bytes: usize,
-) -> Result<Option<String>, McpToolDiscoveryFailure> {
-    match value {
-        Some(value) if value.len() > max_bytes => Err(failure(
-            FailureKind::ResponseTooLarge,
-            format!("MCP {field} exceeded the discovery limit"),
-        )),
-        value => Ok(value),
-    }
+fn truncated_optional_text(value: Option<String>, max_bytes: usize) -> Option<String> {
+    // Titles and descriptions are untrusted hints, not protocol identity or
+    // execution authority. A verbose hint must not make every otherwise valid
+    // tool on the server unusable. Names and schemas remain fail-closed; hints
+    // degrade independently and visibly with an ellipsis.
+    value.map(|value| mcp::truncate_utf8_with_ellipsis(value, max_bytes))
 }
 
 fn json_depth(value: &Value) -> usize {
@@ -1331,6 +1323,32 @@ mod tests {
         let annotations = tool.annotations.expect("annotations");
         assert_eq!(annotations.read_only_hint, Some(true));
         assert_eq!(annotations.destructive_hint, Some(false));
+    }
+
+    #[test]
+    fn tool_projection_truncates_verbose_metadata_without_losing_the_tool() {
+        let tool = project_tool(
+            tool(json!({
+                "name": "search",
+                "title": "A very long title",
+                "description": format!("Notion {}", "雪".repeat(32)),
+                "inputSchema": {"type": "object"},
+                "annotations": {"title": "An equally long annotation title"}
+            })),
+            McpToolDiscoveryLimits {
+                max_text_bytes: 17,
+                ..McpToolDiscoveryLimits::default()
+            },
+        )
+        .expect("verbose hints must not reject an otherwise valid tool");
+        assert_eq!(tool.name, "search");
+        assert!(tool.title.as_ref().is_some_and(|title| title.len() <= 17));
+        assert!(
+            tool.description
+                .as_ref()
+                .is_some_and(|description| description.len() <= 17)
+        );
+        assert!(tool.description.unwrap().ends_with('…'));
     }
 
     #[test]

--- a/docs/roadmap/p143-mcp-tool-discovery.md
+++ b/docs/roadmap/p143-mcp-tool-discovery.md
@@ -532,21 +532,27 @@ proof that `tools/list` is authorized.
 
 ## Limits
 
-Initial production bounds should be configuration constants with conservative
-defaults and hard server caps, for example:
+Production bounds remain hard constants, but their defaults must accommodate
+broad enterprise catalogs rather than only small development fixtures:
 
-- 10 seconds total wall time;
-- 8 pages;
-- 256 tools;
-- 2 MiB total decoded response data;
-- 128 characters per tool name, 4 KiB per title/description;
-- 64 KiB per input/output schema and bounded JSON depth;
+- 30 seconds total wall time;
+- 64 pages;
+- 2,048 tools;
+- 16 MiB total decoded response data;
+- 128 bytes per tool name and 16 KiB per title/description;
+- 512 KiB per input/output schema and JSON depth 64;
 - no more than one active discovery per universe/server;
 - a short per-server cooldown after completion.
 
-Exact values may change during implementation, but every dimension must be
-bounded before the feature is enabled in production. Crossing any completeness
-bound fails discovery without returning a partial inventory.
+Every dimension remains bounded. Crossing an inventory-completeness bound still
+fails discovery without returning a partial inventory. Oversized titles and
+descriptions are the exception: they are untrusted, non-authoritative hints and
+are truncated on a UTF-8 boundary instead of taking down the entire server.
+The unpaginated management projection preserves every tool name but dynamically
+shares 512 KiB of optional title/description text across the inventory so a
+broad server remains below the gateway response budget. Native search keeps the
+larger bounded descriptions internally and returns only one result page at a
+time.
 
 ## Implementation Slices
 


### PR DESCRIPTION
## Summary

- raise bounded MCP discovery limits for large enterprise inventories
- truncate oversized optional titles and descriptions instead of rejecting the whole inventory
- preserve strict validation for tool names and input schemas
- dynamically budget the management API projection so broad inventories stay within the gateway response cap

## Live reproduction

Reproduced against the Notion MCP attached to session `session_f3ba60080b434b8682ade4480f252fc5` using discovery only. The server returned its inventory successfully, but a tool description over the previous 4 KiB limit caused Lightspeed to reject the entire response as `responseTooLarge`. No Notion tools were invoked and no workspace writes were made.

## Validation

- `cargo test -p mcp`
- `cargo test -p temporal-server --lib`
- `cargo test -p llm-runtime`
- `cargo test -p temporal-server --test mcp_live` (credentialed tests compiled and remained ignored)
- `cargo clippy -p mcp -p temporal-server --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`