### PR TITLE
Scale MCP discovery and tool search

### DIFF
--- a/clients/typescript/src/generated/types.ts
+++ b/clients/typescript/src/generated/types.ts
@@ -119,7 +119,12 @@ export type AgentNotification =
  * via the `definition` "ToolItemStatus".
  */
 export type ToolItemStatus =
-  "requested" | "running" | "succeeded" | "failed" | "cancelled" | "unavailable";
+  | "requested"
+  | "running"
+  | "succeeded"
+  | "failed"
+  | "cancelled"
+  | "unavailable";
 /**
  * This interface was referenced by `LightspeedAgentAPI`'s JSON-Schema
  * via the `definition` "ToolCallDisplayGroup".
@@ -256,7 +261,13 @@ export type RunSummarySourceView = {
  * via the `definition` "RunStatus".
  */
 export type RunStatus =
-  "queued" | "running" | "parked" | "cancelling" | "completed" | "failed" | "cancelled";
+  | "queued"
+  | "running"
+  | "parked"
+  | "cancelling"
+  | "completed"
+  | "failed"
+  | "cancelled";
 /**
  * This interface was referenced by `LightspeedAgentAPI`'s JSON-Schema
  * via the `definition` "CompactionPolicy".
@@ -925,7 +936,11 @@ export type BotWhenBusy = "queue" | "steer" | "append";
  * via the `definition` "BotTriggerDisabledReason".
  */
 export type BotTriggerDisabledReason =
-  "breaker" | "poll_failed" | "one_shot" | "operator" | "bot_closed";
+  | "breaker"
+  | "poll_failed"
+  | "one_shot"
+  | "operator"
+  | "bot_closed";
 /**
  * Which session a trigger's events are delivered to; absent means the
  * bot's main session.
@@ -1174,7 +1189,11 @@ export type ChannelProvider = string;
  * via the `definition` "ChannelInboundDecision".
  */
 export type ChannelInboundDecision =
-  "bound" | "paired" | "pairing_required" | "pairing_pending" | "unbound";
+  | "bound"
+  | "paired"
+  | "pairing_required"
+  | "pairing_pending"
+  | "unbound";
 /**
  * How a chat got its route: claimed by an open trigger's first contact,
  * or paired by code.

--- a/crates/api-projection/src/lib.rs
+++ b/crates/api-projection/src/lib.rs
@@ -2320,13 +2320,25 @@ fn tool_call_display(tool_name: &str, arguments: &str) -> Option<ToolCallDisplay
         },
         "mcp_find_tools" => ToolCallDisplayView {
             group: ToolCallDisplayGroup::Explore,
-            verb: "Search MCP tools".to_owned(),
+            verb: json
+                .as_ref()
+                .and_then(|json| json.get("names"))
+                .and_then(Value::as_array)
+                .map_or_else(
+                    || "Search MCP tools".to_owned(),
+                    |_| "Load MCP tool definitions".to_owned(),
+                ),
             target: json
                 .as_ref()
                 .and_then(|json| first_string(json, &["server"])),
-            detail: json
-                .as_ref()
-                .and_then(|json| first_string(json, &["query"])),
+            detail: json.as_ref().and_then(|json| {
+                json.get("names")
+                    .and_then(Value::as_array)
+                    .map(|names| names.iter().filter_map(json_text).collect::<Vec<_>>())
+                    .filter(|names| !names.is_empty())
+                    .map(|names| names.join(", "))
+                    .or_else(|| first_string(json, &["query"]))
+            }),
         },
         "mcp_call" => ToolCallDisplayView {
             group: ToolCallDisplayGroup::Other,
@@ -2516,6 +2528,21 @@ mod tests {
         assert_eq!(display.verb, "lightspeed_models_list");
         assert_eq!(display.target.as_deref(), Some("configurator"));
         assert_ne!(display.verb, "mcp_call");
+    }
+
+    #[test]
+    fn native_mcp_detail_display_names_the_requested_tools() {
+        let display = tool_call_display(
+            "mcp_find_tools",
+            r#"{"server":"configurator","names":["models_list","sessions_read"]}"#,
+        )
+        .expect("display");
+        assert_eq!(display.verb, "Load MCP tool definitions");
+        assert_eq!(display.target.as_deref(), Some("configurator"));
+        assert_eq!(
+            display.detail.as_deref(),
+            Some("models_list, sessions_read")
+        );
     }
 
     #[test]

--- a/crates/llm-runtime/src/anthropic_messages.rs
+++ b/crates/llm-runtime/src/anthropic_messages.rs
@@ -1488,6 +1488,7 @@ mod tests {
                 remote_name: "read".to_owned(),
                 description: Some("Read".to_owned()),
                 input_schema: json!({"type": "object"}),
+                annotations: None,
             }])
         }
     }

--- a/crates/llm-runtime/src/mcp.rs
+++ b/crates/llm-runtime/src/mcp.rs
@@ -9,6 +9,9 @@ pub struct NativeMcpTool {
     pub remote_name: String,
     pub description: Option<String>,
     pub input_schema: Value,
+    /// Standard MCP annotation hints retained for model-facing discovery.
+    /// They are untrusted metadata and never authorize execution or retries.
+    pub annotations: Option<Value>,
 }
 
 #[derive(Clone, Debug, thiserror::Error)]

--- a/crates/llm-runtime/src/openai_completions.rs
+++ b/crates/llm-runtime/src/openai_completions.rs
@@ -1397,6 +1397,7 @@ mod tests {
                 remote_name: "lookup".to_owned(),
                 description: Some("Lookup".to_owned()),
                 input_schema: json!({"type": "object"}),
+                annotations: None,
             }])
         }
     }

--- a/crates/llm-runtime/src/openai_responses.rs
+++ b/crates/llm-runtime/src/openai_responses.rs
@@ -1448,6 +1448,7 @@ mod tests {
                 remote_name: "search_issues".to_owned(),
                 description: Some("Search issues".to_owned()),
                 input_schema: json!({"type": "object", "properties": {"q": {"type": "string"}}}),
+                annotations: None,
             }])
         }
     }

--- a/crates/mcp/src/search.rs
+++ b/crates/mcp/src/search.rs
@@ -20,13 +20,25 @@ impl McpToolSearchQuery {
 
     /// Score one tool against this query. `None` means that no query term
     /// matched strongly enough for the tool to be returned.
-    pub fn score(&self, tool_name: &str, description: Option<&str>) -> Option<McpToolSearchScore> {
+    pub fn score(
+        &self,
+        tool_name: &str,
+        description: Option<&str>,
+        input_schema: &serde_json::Value,
+    ) -> Option<McpToolSearchScore> {
         if self.terms.is_empty() {
             return None;
         }
         let normalized_name = normalize_search_text(tool_name);
         let normalized_description = normalize_search_text(description.unwrap_or_default());
         let name_terms = search_name_terms(&normalized_name);
+        let argument_terms = input_schema
+            .get("properties")
+            .and_then(serde_json::Value::as_object)
+            .into_iter()
+            .flat_map(|properties| properties.keys())
+            .flat_map(|name| search_name_terms(&normalize_search_text(name)))
+            .collect::<Vec<_>>();
         let description_terms = normalized_description
             .split_whitespace()
             .collect::<Vec<_>>();
@@ -40,18 +52,25 @@ impl McpToolSearchQuery {
                 .iter()
                 .filter_map(|candidate| term_score(query_term, candidate))
                 .max();
+            let argument_score = argument_terms
+                .iter()
+                .filter_map(|candidate| term_score(query_term, candidate))
+                .max()
+                .map(|score| score.saturating_sub(5));
             let description_score = description_terms
                 .iter()
                 .filter_map(|candidate| term_score(query_term, candidate))
                 .max()
                 .map(|score| score.saturating_sub(10));
-            let Some(term_score) = name_score.into_iter().chain(description_score).max() else {
+            let name_side_score = name_score.into_iter().chain(argument_score).max();
+            let Some(term_score) = name_side_score.into_iter().chain(description_score).max()
+            else {
                 continue;
             };
             score.matched_terms = score.matched_terms.saturating_add(1);
             score.name_terms = score
                 .name_terms
-                .saturating_add(u16::from(name_score.is_some()));
+                .saturating_add(u16::from(name_side_score.is_some()));
             score.score = score.score.saturating_add(term_score);
         }
         (score.matched_terms > 0).then_some(score)
@@ -129,6 +148,10 @@ fn normalize_search_text(value: &str) -> String {
 mod tests {
     use super::*;
 
+    fn empty_schema() -> serde_json::Value {
+        serde_json::json!({"type": "object"})
+    }
+
     #[test]
     fn normalizes_separators_and_camel_case() {
         assert_eq!(
@@ -136,7 +159,7 @@ mod tests {
             "search git hub issues v2"
         );
         let score = McpToolSearchQuery::new("github issues")
-            .score("SearchGitHubIssues", None)
+            .score("SearchGitHubIssues", None, &empty_schema())
             .expect("camel-case acronym alias");
         assert_eq!(score.matched_terms, 2);
     }
@@ -144,26 +167,28 @@ mod tests {
     #[test]
     fn matches_plurals_partial_queries_and_typos() {
         let plural = McpToolSearchQuery::new("issues")
-            .score("issue", None)
+            .score("issue", None, &empty_schema())
             .expect("plural-prefix match");
         assert_eq!(plural.matched_terms, 1);
         assert_eq!(plural.name_terms, 1);
 
         let query = McpToolSearchQuery::new("search issues");
         let full = query
-            .score("search_issues", None)
+            .score("search_issues", None, &empty_schema())
             .expect("full token match");
-        let partial = query.score("search", None).expect("partial token match");
+        let partial = query
+            .score("search", None, &empty_schema())
+            .expect("partial token match");
         assert!(full > partial);
         assert_eq!(partial.matched_terms, 1);
 
         let typo = McpToolSearchQuery::new("serach issues")
-            .score("search_issue", None)
+            .score("search_issue", None, &empty_schema())
             .expect("typo-tolerant match");
         assert_eq!(typo.matched_terms, 2);
         assert!(
             McpToolSearchQuery::new("calendar")
-                .score("search_issue", None)
+                .score("search_issue", None, &empty_schema())
                 .is_none()
         );
     }
@@ -172,11 +197,33 @@ mod tests {
     fn prefers_names_then_uses_descriptions() {
         let query = McpToolSearchQuery::new("customer lookup");
         let name_match = query
-            .score("customer_lookup", Some("Find a record"))
+            .score("customer_lookup", Some("Find a record"), &empty_schema())
             .expect("name match");
         let description_match = query
-            .score("find_record", Some("Look up a customer account"))
+            .score(
+                "find_record",
+                Some("Look up a customer account"),
+                &empty_schema(),
+            )
             .expect("description match");
         assert!(name_match > description_match);
+    }
+
+    #[test]
+    fn indexes_top_level_argument_names_below_tool_names() {
+        let query = McpToolSearchQuery::new("page id");
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {"page_id": {"type": "string"}}
+        });
+        let argument_match = query
+            .score("update", None, &schema)
+            .expect("argument-name match");
+        let name_match = query
+            .score("page_id", None, &empty_schema())
+            .expect("tool-name match");
+        assert!(name_match > argument_match);
+        assert_eq!(argument_match.matched_terms, 2);
+        assert_eq!(argument_match.name_terms, 2);
     }
 }

--- a/crates/temporal-server/src/gateway/http.rs
+++ b/crates/temporal-server/src/gateway/http.rs
@@ -971,11 +971,14 @@ async fn rpc(
     }
 }
 
-/// Deliberate bulk transfers whose size the caller already chose; the byte
-/// budget guards accidentally unbounded documents, not blob bodies, which
-/// have no smaller page to retry with.
+/// Deliberate bounded bulk transfers. Blob reads have no smaller page to
+/// retry with, while MCP discovery is already constrained by the
+/// discoverer's typed 16 MiB decoded-inventory limit.
 fn response_budget_exempt(method: &str) -> bool {
-    method == api::METHOD_BLOBS_READ
+    matches!(
+        method,
+        api::METHOD_BLOBS_READ | api::METHOD_MCP_SERVERS_TOOLS_DISCOVER
+    )
 }
 
 fn enforce_response_budget(response: JsonRpcResponse) -> JsonRpcResponse {
@@ -1142,6 +1145,34 @@ mod tests {
         assert_eq!(
             response.headers().get(header::CACHE_CONTROL),
             Some(&HeaderValue::from_static("no-store"))
+        );
+    }
+
+    #[test]
+    fn only_deliberate_bulk_methods_are_response_budget_exempt() {
+        assert!(response_budget_exempt(api::METHOD_BLOBS_READ));
+        assert!(response_budget_exempt(
+            api::METHOD_MCP_SERVERS_TOOLS_DISCOVER
+        ));
+        assert!(!response_budget_exempt(api::METHOD_SESSION_READ));
+    }
+
+    #[test]
+    fn non_exempt_oversized_json_rpc_response_is_rejected() {
+        let response = JsonRpcResponse::success(
+            api::RequestId::Number(7),
+            serde_json::json!({"text": "x".repeat(2 * 1024 * 1024)}),
+        );
+        let bounded = enforce_response_budget(response);
+        assert!(bounded.result.is_none());
+        assert_eq!(
+            bounded
+                .error
+                .expect("response-too-large error")
+                .data
+                .expect("typed error data")
+                .kind,
+            AgentApiErrorKind::ResponseTooLarge
         );
     }
 

--- a/crates/temporal-server/src/gateway/service/mcp_api.rs
+++ b/crates/temporal-server/src/gateway/service/mcp_api.rs
@@ -2,13 +2,6 @@ use super::*;
 
 pub(super) const MCP_SERVER_SECRET_NAMESPACE: &str = "mcp_server";
 
-// Discovery is an unpaginated management response today. Preserve every tool
-// name while sharing a bounded amount of optional display text across broad
-// inventories, leaving ample room under the gateway's 2 MiB JSON-RPC budget
-// for names, annotations, and response framing.
-const DISCOVERY_VIEW_TEXT_BUDGET_BYTES: usize = 512 * 1024;
-const DISCOVERY_VIEW_MAX_FIELD_BYTES: usize = 4 * 1024;
-
 pub(super) fn put_mcp_server_record(
     server: McpServerInput,
     now_ms: i64,
@@ -68,21 +61,13 @@ pub(super) fn mcp_server_view(record: mcp::McpServerRecord) -> api::McpServerVie
 pub(super) fn mcp_tool_discovery_success(
     tools: Vec<mcp::DiscoveredMcpTool>,
 ) -> api::McpServerToolsDiscoverResponse {
-    let field_limit = DISCOVERY_VIEW_TEXT_BUDGET_BYTES
-        .checked_div(tools.len().saturating_mul(2).max(1))
-        .unwrap_or(0)
-        .min(DISCOVERY_VIEW_MAX_FIELD_BYTES);
     api::McpServerToolsDiscoverResponse::Success {
         tools: tools
             .into_iter()
             .map(|tool| api::McpAdvertisedToolView {
                 name: tool.name,
-                title: tool
-                    .title
-                    .map(|value| mcp::truncate_utf8_with_ellipsis(value, field_limit)),
-                description: tool
-                    .description
-                    .map(|value| mcp::truncate_utf8_with_ellipsis(value, field_limit)),
+                title: tool.title,
+                description: tool.description,
                 annotations: tool
                     .annotations
                     .map(|annotations| api::McpToolAnnotationsView {
@@ -254,13 +239,19 @@ impl GatewayAgentApi {
                 self.store.as_ref(),
                 "mcp_find_tools",
                 format!(
-                    "Browse or search live MCP tools by partial or fuzzy name/description terms. Available servers: {index}"
+                    "Browse, search, or load full definitions for live MCP tools. Browse with no query or names; search with query (tool names, descriptions, and argument names are indexed); load full definitions with server plus up to five names. Browse and search are byte-paged and may truncate oversized hits; use server plus names when a hit asks for its full definition. Available servers: {index}"
                 ),
                 serde_json::json!({
                     "type": "object",
                     "properties": {
                         "server": {"type": "string"},
                         "query": {"type": "string"},
+                        "names": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "minItems": 1,
+                            "maxItems": 5
+                        },
                         "cursor": {"type": "integer", "minimum": 0}
                     },
                     "additionalProperties": false
@@ -589,37 +580,19 @@ mod tests {
     }
 
     #[test]
-    fn broad_discovery_projection_preserves_names_within_response_budget() {
-        let limits = mcp::McpToolDiscoveryLimits::default();
-        let tools = (0..limits.max_tools)
-            .map(|index| mcp::DiscoveredMcpTool {
-                name: format!("tool_{index:04}_{}", "n".repeat(96)),
-                title: Some("t".repeat(limits.max_text_bytes)),
-                description: Some("d".repeat(limits.max_text_bytes)),
-                input_schema: serde_json::json!({"type": "object"}),
-                annotations: Some(mcp::McpToolAnnotations {
-                    read_only_hint: Some(true),
-                    destructive_hint: Some(false),
-                    idempotent_hint: Some(true),
-                    open_world_hint: Some(false),
-                }),
-            })
-            .collect::<Vec<_>>();
-
-        let response = mcp_tool_discovery_success(tools);
-        let api::McpServerToolsDiscoverResponse::Success { tools } = &response else {
+    fn discovery_projection_preserves_discoverer_retained_text() {
+        let retained = "d".repeat(mcp::McpToolDiscoveryLimits::default().max_text_bytes);
+        let response = mcp_tool_discovery_success(vec![mcp::DiscoveredMcpTool {
+            name: "long_description".to_owned(),
+            title: Some(retained.clone()),
+            description: Some(retained.clone()),
+            input_schema: serde_json::json!({"type": "object"}),
+            annotations: None,
+        }]);
+        let api::McpServerToolsDiscoverResponse::Success { tools } = response else {
             panic!("discovery projection must succeed");
         };
-        assert_eq!(tools.len(), limits.max_tools);
-        assert_eq!(
-            tools.first().unwrap().name,
-            format!("tool_{:04}_{}", 0, "n".repeat(96))
-        );
-        assert!(
-            serde_json::to_vec(&response)
-                .expect("serialize discovery response")
-                .len()
-                < 2 * 1024 * 1024
-        );
+        assert_eq!(tools[0].title.as_deref(), Some(retained.as_str()));
+        assert_eq!(tools[0].description.as_deref(), Some(retained.as_str()));
     }
 }

--- a/crates/temporal-server/src/worker/mcp.rs
+++ b/crates/temporal-server/src/worker/mcp.rs
@@ -57,6 +57,11 @@ pub struct NativeMcpRuntime {
 pub const MCP_INVENTORY_CACHE_TTL: Duration = Duration::from_secs(300);
 /// Short fallback while Lightspeed does not maintain notification subscriptions.
 pub const MCP_LIST_CHANGED_CACHE_TTL: Duration = Duration::from_secs(60);
+const MCP_FIND_HIT_MAX_BYTES: usize = 8 * 1024;
+const MCP_FIND_PAGE_MAX_BYTES: usize = 64 * 1024;
+const MCP_FIND_DETAIL_MAX_NAMES: usize = 5;
+const MCP_FIND_TRUNCATED_NOTE: &str =
+    "Call mcp_find_tools with server and names for the full definition.";
 
 type InventoryCacheKey = (String, u64);
 type InventoryLocks = HashMap<InventoryCacheKey, Arc<Mutex<()>>>;
@@ -249,6 +254,7 @@ impl NativeMcpInventoryResolver {
                 remote_name: tool.name,
                 description: tool.description,
                 input_schema: tool.input_schema,
+                annotations: tool.annotations.map(native_tool_annotations),
             })
             .collect::<Vec<_>>();
         tools.sort_by(|left, right| left.remote_name.cmp(&right.remote_name));
@@ -353,12 +359,75 @@ impl NativeMcpRuntime {
             .as_object()
             .ok_or_else(|| "mcp_find_tools arguments must be a JSON object".to_owned())?;
         let selected_server = object.get("server").and_then(serde_json::Value::as_str);
+        if let Some(server) = selected_server
+            && !targets.iter().any(|target| target.server_id == server)
+        {
+            return Err(format!(
+                "unknown active search-exposure MCP server {server}"
+            ));
+        }
+        let names = match object.get("names") {
+            None => None,
+            Some(serde_json::Value::Array(names)) => {
+                if names.is_empty() {
+                    return Err("mcp_find_tools names must not be empty".to_owned());
+                }
+                if names.len() > MCP_FIND_DETAIL_MAX_NAMES {
+                    return Err(format!(
+                        "mcp_find_tools accepts at most {MCP_FIND_DETAIL_MAX_NAMES} names"
+                    ));
+                }
+                Some(
+                    names
+                        .iter()
+                        .map(|name| {
+                            name.as_str().ok_or_else(|| {
+                                "mcp_find_tools names must contain only strings".to_owned()
+                            })
+                        })
+                        .collect::<Result<Vec<_>, _>>()?,
+                )
+            }
+            Some(_) => return Err("mcp_find_tools names must be an array of strings".to_owned()),
+        };
         let query = object
             .get("query")
             .and_then(serde_json::Value::as_str)
             .map(str::trim)
             .filter(|query| !query.is_empty())
             .map(McpToolSearchQuery::new);
+        if let Some(names) = names {
+            let server =
+                selected_server.ok_or_else(|| "mcp_find_tools names requires server".to_owned())?;
+            if object.contains_key("query") || object.contains_key("cursor") {
+                return Err("mcp_find_tools detail mode does not accept query or cursor".to_owned());
+            }
+            let target = targets
+                .iter()
+                .find(|target| target.server_id == server)
+                .expect("selected server was validated");
+            let spec = spec_from_target(target, engine::RemoteMcpExposure::Search);
+            let inventory = self
+                .inventory
+                .list_tools(&spec)
+                .await
+                .map_err(|error| error.to_string())?;
+            let mut tools = Vec::with_capacity(names.len());
+            for name in names {
+                let tool = inventory
+                    .iter()
+                    .find(|tool| tool.remote_name == name)
+                    .ok_or_else(|| format!("MCP server {server} does not advertise tool {name}"))?;
+                tools.push(full_tool_definition(server, tool));
+            }
+            let output = serde_json::json!({"tools": tools, "nextCursor": null});
+            return Ok(NativeMcpExecutionOutcome::Completed {
+                visible: serde_json::to_string(&output).map_err(|error| error.to_string())?,
+                output,
+                is_error: false,
+                assets: Vec::new(),
+            });
+        }
         let cursor = object
             .get("cursor")
             .and_then(serde_json::Value::as_u64)
@@ -377,9 +446,11 @@ impl NativeMcpRuntime {
             {
                 let rank = match query.as_ref() {
                     Some(query) => {
-                        let Some(rank) =
-                            query.score(&tool.remote_name, tool.description.as_deref())
-                        else {
+                        let Some(rank) = query.score(
+                            &tool.remote_name,
+                            tool.description.as_deref(),
+                            &tool.input_schema,
+                        ) else {
                             continue;
                         };
                         Some(rank)
@@ -389,16 +460,6 @@ impl NativeMcpRuntime {
                 matches.push((rank, target.server_id.clone(), tool));
             }
         }
-        if matches.is_empty()
-            && let Some(selected_server) = selected_server
-            && !targets
-                .iter()
-                .any(|target| target.server_id == selected_server)
-        {
-            return Err(format!(
-                "unknown active search-exposure MCP server {selected_server}"
-            ));
-        }
         matches.sort_by(|left, right| {
             right
                 .0
@@ -406,30 +467,9 @@ impl NativeMcpRuntime {
                 .then_with(|| left.1.cmp(&right.1))
                 .then_with(|| left.2.remote_name.cmp(&right.2.remote_name))
         });
-        const PAGE_SIZE: usize = 20;
-        let page = matches
-            .iter()
-            .skip(cursor)
-            .take(PAGE_SIZE)
-            .map(|(_, server, tool)| {
-                let mut value = serde_json::json!({
-                    "server": server,
-                    "name": tool.remote_name,
-                    "description": tool.description,
-                });
-                if query.is_some() {
-                    value
-                        .as_object_mut()
-                        .expect("tool result object")
-                        .insert("inputSchema".to_owned(), tool.input_schema.clone());
-                }
-                value
-            })
-            .collect::<Vec<_>>();
-        let next_cursor = (cursor + page.len() < matches.len()).then_some(cursor + page.len());
-        let output = serde_json::json!({"tools": page, "nextCursor": next_cursor});
+        let output = paged_tool_output(&matches, cursor)?;
         Ok(NativeMcpExecutionOutcome::Completed {
-            visible: serde_json::to_string_pretty(&output).map_err(|error| error.to_string())?,
+            visible: serde_json::to_string(&output).map_err(|error| error.to_string())?,
             output,
             is_error: false,
             assets: Vec::new(),
@@ -467,14 +507,7 @@ impl NativeMcpRuntime {
                     target.server_id
                 )
             })?;
-        let validator = jsonschema::validator_for(&tool.input_schema).map_err(|error| {
-            format!("MCP tool {tool_name} has an invalid input schema: {error}")
-        })?;
-        validator
-            .validate(&serde_json::Value::Object(arguments.clone()))
-            .map_err(|error| {
-                format!("arguments for MCP tool {tool_name} do not match its schema: {error}")
-            })
+        validate_mcp_arguments(tool_name, tool, arguments)
     }
 
     async fn call(
@@ -611,6 +644,154 @@ impl NativeMcpRuntime {
             Err(error) => Err(format!("resolve MCP credential: {error}")),
         }
     }
+}
+
+fn native_tool_annotations(annotations: mcp::McpToolAnnotations) -> serde_json::Value {
+    let mut value = serde_json::Map::new();
+    for (name, hint) in [
+        ("readOnlyHint", annotations.read_only_hint),
+        ("destructiveHint", annotations.destructive_hint),
+        ("idempotentHint", annotations.idempotent_hint),
+        ("openWorldHint", annotations.open_world_hint),
+    ] {
+        if let Some(hint) = hint {
+            value.insert(name.to_owned(), serde_json::Value::Bool(hint));
+        }
+    }
+    serde_json::Value::Object(value)
+}
+
+fn validate_mcp_arguments(
+    tool_name: &str,
+    tool: &NativeMcpTool,
+    arguments: &serde_json::Map<String, serde_json::Value>,
+) -> Result<(), String> {
+    let schema = serde_json::to_string(&tool.input_schema).map_err(|error| error.to_string())?;
+    let validator = jsonschema::validator_for(&tool.input_schema).map_err(|error| {
+        format!("MCP tool {tool_name} has an invalid input schema: {error}; input schema: {schema}")
+    })?;
+    validator
+        .validate(&serde_json::Value::Object(arguments.clone()))
+        .map_err(|error| {
+            format!(
+                "arguments for MCP tool {tool_name} do not match its schema: {error}; input schema: {schema}"
+            )
+        })
+}
+
+fn full_tool_definition(server: &str, tool: &NativeMcpTool) -> serde_json::Value {
+    serde_json::json!({
+        "server": server,
+        "name": tool.remote_name,
+        "description": tool.description,
+        "inputSchema": tool.input_schema,
+        "annotations": tool.annotations,
+    })
+}
+
+fn compact_search_hit(server: &str, tool: &NativeMcpTool) -> Result<serde_json::Value, String> {
+    let full = full_tool_definition(server, tool);
+    if serde_json::to_vec(&full)
+        .map_err(|error| error.to_string())?
+        .len()
+        <= MCP_FIND_HIT_MAX_BYTES
+    {
+        return Ok(full);
+    }
+
+    let mut hit = serde_json::json!({
+        "server": server,
+        "name": tool.remote_name,
+        "description": tool.description.as_ref().map(|_| ""),
+        "inputSchema": tool.input_schema,
+        "annotations": tool.annotations,
+        "truncated": MCP_FIND_TRUNCATED_NOTE,
+    });
+
+    if serialized_len(&hit)? > MCP_FIND_HIT_MAX_BYTES {
+        let mut argument_names = tool
+            .input_schema
+            .get("properties")
+            .and_then(serde_json::Value::as_object)
+            .into_iter()
+            .flat_map(|properties| properties.keys().cloned())
+            .collect::<Vec<_>>();
+        argument_names.sort();
+        hit["inputSchema"] = serde_json::json!(argument_names);
+
+        // The schema bounds normally make the complete argument-name list fit.
+        // Keep the hit invariant defensive even for an adversarial schema with
+        // thousands of long top-level properties.
+        while serialized_len(&hit)? > MCP_FIND_HIT_MAX_BYTES {
+            let Some(names) = hit["inputSchema"].as_array_mut() else {
+                break;
+            };
+            if names.pop().is_none() {
+                break;
+            }
+        }
+    }
+
+    if let Some(description) = tool.description.as_deref() {
+        let mut boundaries = description
+            .char_indices()
+            .map(|(index, _)| index)
+            .collect::<Vec<_>>();
+        boundaries.push(description.len());
+        boundaries.sort_unstable();
+        boundaries.dedup();
+
+        let mut low = 0;
+        let mut high = boundaries.len();
+        while low < high {
+            let middle = (low + high) / 2;
+            hit["description"] =
+                serde_json::Value::String(description[..boundaries[middle]].to_owned());
+            if serialized_len(&hit)? <= MCP_FIND_HIT_MAX_BYTES {
+                low = middle + 1;
+            } else {
+                high = middle;
+            }
+        }
+        let selected = low.saturating_sub(1);
+        hit["description"] =
+            serde_json::Value::String(description[..boundaries[selected]].to_owned());
+    }
+
+    if serialized_len(&hit)? > MCP_FIND_HIT_MAX_BYTES {
+        return Err("MCP tool identity exceeds the search hit byte limit".to_owned());
+    }
+    Ok(hit)
+}
+
+fn paged_tool_output(
+    matches: &[(
+        Option<mcp::search::McpToolSearchScore>,
+        String,
+        NativeMcpTool,
+    )],
+    cursor: usize,
+) -> Result<serde_json::Value, String> {
+    let mut page = Vec::new();
+    for (_, server, tool) in matches.iter().skip(cursor) {
+        page.push(compact_search_hit(server, tool)?);
+        let next_cursor = (cursor + page.len() < matches.len()).then_some(cursor + page.len());
+        let candidate = serde_json::json!({"tools": page, "nextCursor": next_cursor});
+        if serialized_len(&candidate)? > MCP_FIND_PAGE_MAX_BYTES && page.len() > 1 {
+            page.pop();
+            break;
+        }
+    }
+    let next_cursor = (cursor + page.len() < matches.len()).then_some(cursor + page.len());
+    let output = serde_json::json!({"tools": page, "nextCursor": next_cursor});
+    debug_assert!(serialized_len(&output).is_ok_and(|length| length <= MCP_FIND_PAGE_MAX_BYTES));
+    Ok(output)
+}
+
+fn serialized_len(value: &serde_json::Value) -> Result<usize, String> {
+    serde_json::to_vec(value)
+        .map(|bytes| bytes.len())
+        .map_err(|error| error.to_string())
 }
 
 fn extract_mcp_assets(
@@ -803,6 +984,19 @@ mod tests {
 
     use super::*;
 
+    fn native_tool(
+        name: &str,
+        description: Option<String>,
+        input_schema: serde_json::Value,
+    ) -> NativeMcpTool {
+        NativeMcpTool {
+            remote_name: name.to_owned(),
+            description,
+            input_schema,
+            annotations: Some(serde_json::json!({"readOnlyHint": true})),
+        }
+    }
+
     struct CountingDiscoverer {
         calls: AtomicUsize,
         tools_list_changed: bool,
@@ -967,5 +1161,112 @@ mod tests {
         assert!(!value.to_string().contains("aGVsbG8="));
         attach_mcp_asset_refs(&mut value, &[engine::BlobRef::from_bytes(b"hello")]);
         assert!(value.to_string().contains("sha256:"));
+    }
+
+    #[test]
+    fn search_hits_are_uniform_and_oversized_descriptions_are_utf8_safe() {
+        let whole = compact_search_hit(
+            "docs",
+            &native_tool(
+                "read",
+                Some("Read a document".to_owned()),
+                serde_json::json!({
+                    "type": "object",
+                    "properties": {"page_id": {"type": "string"}}
+                }),
+            ),
+        )
+        .expect("whole hit");
+        assert_eq!(
+            whole["inputSchema"]["properties"]["page_id"]["type"],
+            "string"
+        );
+        assert_eq!(whole["annotations"]["readOnlyHint"], true);
+        assert!(whole.get("truncated").is_none());
+
+        let oversized = compact_search_hit(
+            "docs",
+            &native_tool(
+                "long",
+                Some("é".repeat(8_000)),
+                serde_json::json!({"type": "object"}),
+            ),
+        )
+        .expect("bounded hit");
+        assert!(serialized_len(&oversized).unwrap() <= MCP_FIND_HIT_MAX_BYTES);
+        assert_eq!(oversized["truncated"], MCP_FIND_TRUNCATED_NOTE);
+        assert!(
+            oversized["description"]
+                .as_str()
+                .unwrap()
+                .is_char_boundary(oversized["description"].as_str().unwrap().len())
+        );
+    }
+
+    #[test]
+    fn oversized_schemas_fall_back_to_top_level_argument_names() {
+        let hit = compact_search_hit(
+            "docs",
+            &native_tool(
+                "update",
+                Some("Update a page".to_owned()),
+                serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "page_id": {"type": "string", "description": "x".repeat(12_000)},
+                        "title": {"type": "string"}
+                    }
+                }),
+            ),
+        )
+        .expect("bounded hit");
+        assert_eq!(hit["inputSchema"], serde_json::json!(["page_id", "title"]));
+        assert_eq!(hit["truncated"], MCP_FIND_TRUNCATED_NOTE);
+        assert!(serialized_len(&hit).unwrap() <= MCP_FIND_HIT_MAX_BYTES);
+    }
+
+    #[test]
+    fn argument_validation_errors_include_the_full_input_schema() {
+        let tool = native_tool(
+            "update",
+            None,
+            serde_json::json!({
+                "type": "object",
+                "properties": {"page_id": {"type": "string"}},
+                "required": ["page_id"]
+            }),
+        );
+        let error = validate_mcp_arguments("update", &tool, &serde_json::Map::new())
+            .expect_err("missing required argument");
+        assert!(error.contains("input schema:"));
+        assert!(error.contains(r#""required":["page_id"]"#));
+    }
+
+    #[test]
+    fn search_pages_use_compact_byte_budget_and_advance_cursor() {
+        let matches = (0..40)
+            .map(|index| {
+                (
+                    None,
+                    "docs".to_owned(),
+                    native_tool(
+                        &format!("tool_{index:02}"),
+                        Some("d".repeat(2_000)),
+                        serde_json::json!({"type": "object"}),
+                    ),
+                )
+            })
+            .collect::<Vec<_>>();
+        let first = paged_tool_output(&matches, 0).expect("first page");
+        assert!(serialized_len(&first).unwrap() <= MCP_FIND_PAGE_MAX_BYTES);
+        let first_len = first["tools"].as_array().unwrap().len();
+        let cursor = first["nextCursor"].as_u64().expect("next cursor") as usize;
+        assert_eq!(cursor, first_len);
+        assert!(cursor > 0);
+
+        let second = paged_tool_output(&matches, cursor).expect("second page");
+        assert!(serialized_len(&second).unwrap() <= MCP_FIND_PAGE_MAX_BYTES);
+        assert_eq!(second["tools"][0]["name"], format!("tool_{cursor:02}"));
+        assert!(second["nextCursor"].is_null());
     }
 }

--- a/crates/temporal-server/tests/mcp_live.rs
+++ b/crates/temporal-server/tests/mcp_live.rs
@@ -160,17 +160,70 @@ impl CoreAgentLlm for MatrixScriptedLlm {
                 .await
             }
             "matrix_browse_1" => {
-                assert_find_page(&result, 20, Some(20), "catalog_tool_000")?;
+                let page = find_page(&result, "catalog_tool_000")?;
+                let cursor =
+                    page["nextCursor"]
+                        .as_u64()
+                        .ok_or_else(|| CoreAgentIoError::Failed {
+                            message: format!("first MCP browse page did not continue: {result}"),
+                        })?;
                 self.tool_call(
                     &request,
                     "mcp_find_tools",
                     "matrix_browse_2",
-                    json!({"server": self.ids.large, "cursor": 20}),
+                    json!({"server": self.ids.large, "cursor": cursor}),
                 )
                 .await
             }
             "matrix_browse_2" => {
-                assert_find_page(&result, 20, Some(40), "catalog_tool_020")?;
+                let page = find_page(&result, "catalog_tool_044")?;
+                if !page["nextCursor"].is_null() {
+                    return Err(CoreAgentIoError::Failed {
+                        message: format!("second MCP browse page did not finish: {result}"),
+                    });
+                }
+                self.tool_call(
+                    &request,
+                    "mcp_find_tools",
+                    "matrix_oversized",
+                    json!({"server": self.ids.large, "query": "catalog_tool_044"}),
+                )
+                .await
+            }
+            "matrix_oversized" => {
+                let page = find_page(&result, "catalog_tool_044")?;
+                let tool = page["tools"]
+                    .as_array()
+                    .and_then(|tools| tools.iter().find(|tool| tool["name"] == "catalog_tool_044"))
+                    .ok_or_else(|| CoreAgentIoError::Failed {
+                        message: format!("oversized MCP hit is absent: {result}"),
+                    })?;
+                if tool["truncated"].as_str().is_none()
+                    || serde_json::to_vec(tool).map_err(io_error)?.len() > 8 * 1024
+                {
+                    return Err(CoreAgentIoError::Failed {
+                        message: format!("oversized MCP hit was not bounded: {result}"),
+                    });
+                }
+                self.tool_call(
+                    &request,
+                    "mcp_find_tools",
+                    "matrix_detail",
+                    json!({"server": self.ids.large, "names": ["catalog_tool_044"]}),
+                )
+                .await
+            }
+            "matrix_detail" => {
+                let page = find_page(&result, "catalog_tool_044")?;
+                let tool = &page["tools"][0];
+                if tool.get("truncated").is_some()
+                    || tool["description"].as_str().map(str::len) != Some(16_000)
+                    || tool["inputSchema"]["properties"]["value"]["type"] != "string"
+                {
+                    return Err(CoreAgentIoError::Failed {
+                        message: format!("MCP detail did not return the full definition: {result}"),
+                    });
+                }
                 self.tool_call(
                     &request,
                     "mcp_find_tools",
@@ -185,7 +238,7 @@ impl CoreAgentLlm for MatrixScriptedLlm {
                     &request,
                     "mcp_find_tools",
                     "matrix_selected",
-                    json!({"server": self.ids.selected, "query": "catlog tools 039"}),
+                    json!({"server": self.ids.selected, "query": "value"}),
                 )
                 .await
             }
@@ -540,19 +593,13 @@ fn assert_find_page(
     next_cursor: Option<u64>,
     expected_name: &str,
 ) -> Result<(), CoreAgentIoError> {
-    let value: Value = serde_json::from_str(text).map_err(io_error)?;
+    let value = find_page(text, expected_name)?;
     let tools = value["tools"]
         .as_array()
         .ok_or_else(|| CoreAgentIoError::Failed {
             message: format!("MCP find result has no tools array: {text}"),
         })?;
-    if tools.len() != expected_len
-        || value["nextCursor"].as_u64() != next_cursor
-        || (!expected_name.is_empty()
-            && !tools
-                .iter()
-                .any(|tool| tool["name"].as_str() == Some(expected_name)))
-    {
+    if tools.len() != expected_len || value["nextCursor"].as_u64() != next_cursor {
         return Err(CoreAgentIoError::Failed {
             message: format!(
                 "unexpected MCP find page: len={}, next={:?}, expected name={expected_name:?}, value={text}",
@@ -562,6 +609,30 @@ fn assert_find_page(
         });
     }
     Ok(())
+}
+
+fn find_page(text: &str, expected_name: &str) -> Result<Value, CoreAgentIoError> {
+    if text.len() > 64 * 1024 {
+        return Err(CoreAgentIoError::Failed {
+            message: format!("MCP find result exceeded 64 KiB: {} bytes", text.len()),
+        });
+    }
+    let value: Value = serde_json::from_str(text).map_err(io_error)?;
+    let tools = value["tools"]
+        .as_array()
+        .ok_or_else(|| CoreAgentIoError::Failed {
+            message: format!("MCP find result has no tools array: {text}"),
+        })?;
+    if !expected_name.is_empty()
+        && !tools
+            .iter()
+            .any(|tool| tool["name"].as_str() == Some(expected_name))
+    {
+        return Err(CoreAgentIoError::Failed {
+            message: format!("MCP find page did not contain {expected_name:?}: {text}"),
+        });
+    }
+    Ok(value)
 }
 
 fn require_contains(text: &str, needle: &str, step: &str) -> Result<(), CoreAgentIoError> {
@@ -725,9 +796,14 @@ async fn fixture_tools_list(
     let end = (offset + LARGE_PAGE_SIZE).min(count);
     let tools = (offset..end)
         .map(|index| {
+            let description = if index == 44 {
+                "é".repeat(8_000)
+            } else {
+                format!("Catalog fixture operation {index:03} {}", "d".repeat(2_000))
+            };
             json!({
                 "name": format!("catalog_tool_{index:03}"),
-                "description": format!("Catalog fixture operation {index:03}"),
+                "description": description,
                 "inputSchema": {
                     "type": "object",
                     "properties": {"value": {"type": "string"}},

--- a/docs/roadmap/p143-mcp-tool-discovery.md
+++ b/docs/roadmap/p143-mcp-tool-discovery.md
@@ -548,11 +548,9 @@ Every dimension remains bounded. Crossing an inventory-completeness bound still
 fails discovery without returning a partial inventory. Oversized titles and
 descriptions are the exception: they are untrusted, non-authoritative hints and
 are truncated on a UTF-8 boundary instead of taking down the entire server.
-The unpaginated management projection preserves every tool name but dynamically
-shares 512 KiB of optional title/description text across the inventory so a
-broad server remains below the gateway response budget. Native search keeps the
-larger bounded descriptions internally and returns only one result page at a
-time.
+The unpaginated management projection returns the retained discovery text
+unchanged. Native search keeps those bounded descriptions internally and
+returns only one byte-bounded result page at a time.
 
 ## Implementation Slices
 

--- a/docs/roadmap/p145-native-mcp-execution.md
+++ b/docs/roadmap/p145-native-mcp-execution.md
@@ -173,20 +173,17 @@ the concurrency tools pulled in when a workflow binding exposes model-owned
 promises):
 
 ```text
-mcp_find_tools { server?, query? }
+mcp_find_tools { server?, query?, names?, cursor? }
 mcp_call       { server, tool, arguments }
 ```
 
-- `mcp_find_tools` browses or searches one server's live inventory through
-  the same worker-local cached resolver that injection uses. Results are
-  ordinary tool results: the matching tools' names, descriptions, and full
-  input schemas for a bounded top-K; browse (no query) returns names and
-  one-line descriptions, paginated. Matching is simple and deterministic:
-  separators and camelCase become token boundaries; exact names, token
-  coverage, name matches, conservative prefix/plural matches, and
-  Jaro-Winkler typo similarity determine rank in that order. Partial
-  multi-token matches remain eligible, and no embeddings are involved. Only
-  allowlisted tools are ever returned; search never widens Selected policy.
+- `mcp_find_tools` browses, searches, or loads selected full definitions from
+  one server's live inventory through the same worker-local cached resolver
+  that injection uses. The byte-bounded hit shape, pagination rules, detail
+  mode, and argument-name indexing are specified by
+  [P148](p148-scalable-mcp-discovery-and-tool-search.md). Matching remains
+  deterministic and lexical; only allowlisted tools are ever returned, so
+  search never widens Selected policy.
 - `mcp_call` executes one tool through the same pinned per-call path as an
   injected call: audience check, broker resolution, `tools/call`, result
   mapping, bounds. The runtime validates that `server` names an active

--- a/docs/roadmap/p148-scalable-mcp-discovery-and-tool-search.md
+++ b/docs/roadmap/p148-scalable-mcp-discovery-and-tool-search.md
@@ -2,8 +2,10 @@
 
 **Status**
 
-- Proposed 2026-09-02 after validating Notion's 41-tool MCP server on hz01.
-- Reviewed and simplified 2026-09-02. Dropped: management pagination and a
+- Implemented 2026-09-02 across management discovery, transcript expansion,
+  native MCP search/detail retrieval, projection, and tests.
+- Proposed and reviewed 2026-09-02 after validating Notion's 41-tool MCP
+  server on hz01. Dropped: management pagination and a
   tool-detail method, truncation metadata, search-result tiers, aggregate
   context budgets, configurable limits, telemetry. Kept: one rendering rule
   for every search hit, byte-paged results, and a `names` mode that returns

--- a/docs/roadmap/p148-scalable-mcp-discovery-and-tool-search.md
+++ b/docs/roadmap/p148-scalable-mcp-discovery-and-tool-search.md
@@ -1,0 +1,85 @@
+# P148 — Scalable MCP Discovery and Tool Search
+
+**Status**
+
+- Proposed 2026-09-02 after validating Notion's 41-tool MCP server on hz01.
+- Builds on [P143](p143-mcp-tool-discovery.md) and
+  [P145](p145-native-mcp-execution.md). It keeps bounded discovery and native
+  search exposure, but supersedes their sizing, projection, and search-result
+  policies where large inventories are silently shortened or over-delivered.
+
+## Problem
+
+The Notion validation exposed three different behaviors that look like one
+failure:
+
+- management discovery really truncates each title or description at 4 KiB;
+  four Notion descriptions were shortened, including one from 9,172 to 4,096
+  bytes;
+- session event projection shows only the first 4 KiB of an entire tool result,
+  even though the complete CAS blob remains available and is sent to the model;
+- `mcp_find_tools` returns 20 full descriptions per page and, for a query, also
+  returns every matching input schema without an aggregate result budget.
+
+The first loses useful operator-visible metadata, the second misleadingly
+looks like data loss, and the third can waste context or produce a very large
+result when schemas approach their individual limits. The current 16 KiB
+description and 2,048-tool discovery bounds did not affect Notion, but they are
+implementation policy rather than MCP protocol limits and are too narrow for
+the enterprise servers this path must support.
+
+Large model context windows do not make eager inventory injection desirable.
+They should let a selected tool retain its complete definition, while search
+keeps unrelated definitions out of the prompt.
+
+## Decision
+
+Separate four concerns instead of using one set of truncation constants:
+
+1. **Discovery safety envelope.** Proposed defaults are keep (even reduce) to 1024 tools, 256
+   pages, 64 MiB of decoded inventory, 128 KiB per title/description, 2 MiB per
+   schema, and JSON depth 64. These remain configurable with a larger absolute
+   deployment ceiling. Crossing a completeness bound returns a typed failure;
+   shortening optional text must set `truncated` and `originalBytes` rather
+   than silently appending an ellipsis.
+2. **Management projection.** Make discovery results cursor-paginated. List
+   pages return compact summaries and explicit truncation metadata; a tool
+   detail method returns the retained description, annotations, and schemas.
+   The UI loads detail on expansion instead of forcing the whole inventory
+   through one gateway response.
+3. **Model retrieval.** Keep only `mcp_find_tools` and `mcp_call` in context for
+   search-exposure servers. Search ranks names, titles, descriptions, argument
+   names, and argument descriptions; it returns five results by default and at
+   most twenty. Browse returns summaries. A detail operation returns the full
+   definition for one or a few selected tools. Search pages have a 256 KiB
+   serialized hard budget and always return a cursor when matches remain.
+4. **Session presentation.** Keep the small inline event preview, but label it
+   with displayed and total bytes and let the client expand or download the
+   existing `contentRef`. Preview truncation and source truncation must be
+   visually distinct.
+
+Limits are enforced in bytes for transport and memory safety. Model adapters
+also account for tokens and may request fewer results, but they must not
+silently rewrite a selected tool definition. Telemetry records inventory size,
+largest fields, pages, search-result bytes, and each applied bound without
+recording tool metadata or credentials.
+
+## Acceptance
+
+- The live Notion inventory shows all 41 tools and all four previously shortened
+  descriptions through tool detail.
+- A transcript initially renders a bounded preview and can retrieve the exact
+  complete search result from its CAS reference.
+- Synthetic 10,000-tool and maximum-schema fixtures remain within declared
+  memory, response, and context budgets; pagination cannot loop indefinitely.
+- A natural-language query finds tools from argument metadata and returns a
+  small ranked set; obtaining a full selected definition never requires
+  browsing the entire inventory.
+- Every refusal or partial field identifies the specific bound that applied.
+
+## Non-Goals
+
+- Preloading every advertised tool because a model has a large context window.
+- Persisting a management discovery snapshot as execution authority.
+- Accepting unbounded responses or inventories; a 1 GiB catalog remains a hard
+  failure.

--- a/docs/roadmap/p148-scalable-mcp-discovery-and-tool-search.md
+++ b/docs/roadmap/p148-scalable-mcp-discovery-and-tool-search.md
@@ -3,83 +3,190 @@
 **Status**
 
 - Proposed 2026-09-02 after validating Notion's 41-tool MCP server on hz01.
+- Reviewed and simplified 2026-09-02. Dropped: management pagination and a
+  tool-detail method, truncation metadata, search-result tiers, aggregate
+  context budgets, configurable limits, telemetry. Kept: one rendering rule
+  for every search hit, byte-paged results, and a `names` mode that returns
+  full definitions.
 - Builds on [P143](p143-mcp-tool-discovery.md) and
-  [P145](p145-native-mcp-execution.md). It keeps bounded discovery and native
-  search exposure, but supersedes their sizing, projection, and search-result
-  policies where large inventories are silently shortened or over-delivered.
+  [P145](p145-native-mcp-execution.md). Supersedes P143's management view
+  truncation and P145's search-result shape ("full input schemas for a
+  bounded top-K; browse returns names and one-line descriptions"). The
+  discovery limits themselves stay as documented in P143.
 
 ## Problem
 
-The Notion validation exposed three different behaviors that look like one
-failure:
+The Notion validation exposed three behaviors that look like one failure:
 
-- management discovery really truncates each title or description at 4 KiB;
-  four Notion descriptions were shortened, including one from 9,172 to 4,096
-  bytes;
-- session event projection shows only the first 4 KiB of an entire tool result,
-  even though the complete CAS blob remains available and is sent to the model;
-- `mcp_find_tools` returns 20 full descriptions per page and, for a query, also
-  returns every matching input schema without an aggregate result budget.
+1. **Management discovery truncates each title and description at 4 KiB.**
+   That is not the discoverer's 16 KiB text bound. It is the gateway view
+   projection in `mcp_api.rs`, which shares a 512 KiB text budget across the
+   inventory under a static 4 KiB per-field cap so the response stays below
+   the gateway's global 2 MiB JSON-RPC response guard. Four Notion
+   descriptions were shortened, one from 9,172 bytes.
+2. **The transcript shows only the first 4 KiB of each context entry.** The
+   API already reports `textTruncated` and `contentRef`, and `blobs/read` is
+   exempt from the response guard, but the web UI never reads
+   `textTruncated`. A bounded preview therefore reads as data loss.
+3. **`mcp_find_tools` over-delivers.** It returns 20 hits per page with full
+   descriptions and, for a query, the full input schema of every hit. The
+   result is stored as model-visible text without the 64 KiB model-visible
+   cap that inline tools get. Raising the discovery bounds to 16 KiB text and
+   512 KiB schema moved the worst case for one search result from roughly
+   1.3 MiB to roughly 10 MiB. The scorer qualifies a tool on any single
+   matched term, so a broad query against long descriptions matches most of
+   an inventory.
 
-The first loses useful operator-visible metadata, the second misleadingly
-looks like data loss, and the third can waste context or produce a very large
-result when schemas approach their individual limits. The current 16 KiB
-description and 2,048-tool discovery bounds did not affect Notion, but they are
-implementation policy rather than MCP protocol limits and are too narrow for
-the enterprise servers this path must support.
-
-Large model context windows do not make eager inventory injection desirable.
-They should let a selected tool retain its complete definition, while search
-keeps unrelated definitions out of the prompt.
+The first two are presentation problems with truncation in the wrong layer.
+The third is a context-shape problem: what lands in the model's context on
+every search, before it has chosen anything. Larger limits fix the first and
+make the third worse.
 
 ## Decision
 
-Separate four concerns instead of using one set of truncation constants:
+Three small changes. No new API methods, no pagination of management
+discovery, no truncation metadata, no per-deployment configuration.
 
-1. **Discovery safety envelope.** Proposed defaults are keep (even reduce) to 1024 tools, 256
-   pages, 64 MiB of decoded inventory, 128 KiB per title/description, 2 MiB per
-   schema, and JSON depth 64. These remain configurable with a larger absolute
-   deployment ceiling. Crossing a completeness bound returns a typed failure;
-   shortening optional text must set `truncated` and `originalBytes` rather
-   than silently appending an ellipsis.
-2. **Management projection.** Make discovery results cursor-paginated. List
-   pages return compact summaries and explicit truncation metadata; a tool
-   detail method returns the retained description, annotations, and schemas.
-   The UI loads detail on expansion instead of forcing the whole inventory
-   through one gateway response.
-3. **Model retrieval.** Keep only `mcp_find_tools` and `mcp_call` in context for
-   search-exposure servers. Search ranks names, titles, descriptions, argument
-   names, and argument descriptions; it returns five results by default and at
-   most twenty. Browse returns summaries. A detail operation returns the full
-   definition for one or a few selected tools. Search pages have a 256 KiB
-   serialized hard budget and always return a cursor when matches remain.
-4. **Session presentation.** Keep the small inline event preview, but label it
-   with displayed and total bytes and let the client expand or download the
-   existing `contentRef`. Preview truncation and source truncation must be
-   visually distinct.
+### Management discovery: exempt, do not truncate
 
-Limits are enforced in bytes for transport and memory safety. Model adapters
-also account for tokens and may request fewer results, but they must not
-silently rewrite a selected tool definition. Telemetry records inventory size,
-largest fields, pages, search-result bytes, and each applied bound without
-recording tool metadata or credentials.
+- Add the discovery method to the gateway's response-budget exemption beside
+  `blobs/read`. Discovery is a deliberate bulk transfer that the discoverer
+  already bounds with its decoded-inventory limit (16 MiB, typed failure).
+  The 2 MiB guard exists for accidentally unbounded documents and does not
+  apply.
+- Delete the view-level text budget and per-field cap in
+  `mcp_tool_discovery_success` together with the test that asserts them. The
+  view returns whatever the discoverer retained; the discoverer's own 16 KiB
+  UTF-8 truncation with an ellipsis stays.
+- The web UI keeps its client-side filter and scroll box. It may clamp
+  description lines visually. That is a UI choice and needs nothing from the
+  backend.
+
+Fallback, only if a 16 MiB management response proves unacceptable: keep the
+guard, raise the per-field cap to the discoverer's 16 KiB bound and the shared
+budget to about 1.5 MiB. That leaves inventories up to roughly 48 tools fully
+intact and degrades larger ones visibly. Not the preferred path.
+
+### Session transcript: UI only
+
+- The web UI renders entries with `textTruncated` as the inline text, a
+  truncated marker, and an expand action that reads the complete body through
+  `blobs/read` by `contentRef`.
+- No DTO change. Session content is never truncated at the source, so there
+  is nothing to distinguish the preview from.
+
+### Model retrieval: one hit shape, byte-paged, plus `names`
+
+Contract. The meta-tool schema and description live in `mcp_api.rs`; the
+description must explain the three modes to the model.
+
+```text
+mcp_find_tools { server?, query?, names?, cursor? }
+
+browse  (no query, no names)  every allowlisted tool, ordered by server, name
+search  (query)               ranked by the existing scorer; argument names
+                              are indexed
+detail  (server + names)      up to five tools, full definition, no window
+```
+
+Every browse or search hit has one shape:
+
+```json
+{
+  "server": "notion",
+  "name": "update-page",
+  "description": "...",
+  "inputSchema": { "...": "..." },
+  "annotations": { "...": "..." },
+  "truncated": "Call mcp_find_tools with server and names for the full definition."
+}
+```
+
+- A hit is rendered whole when its serialized form is at or under 8 KiB.
+  Otherwise the description is cut first, on a UTF-8 boundary, until the hit
+  fits. If the input schema alone does not fit, it is replaced by the list of
+  top-level argument names. `truncated` carries the note above and is absent
+  on whole hits.
+- Pages fill in rank order until 64 KiB of serialized hits, always at least
+  one hit, then return `nextCursor`. The cursor stays an integer offset.
+- `names` requires `server`, accepts at most five names, and returns full
+  definitions with no window. A tool with a 512 KiB schema is the operator's
+  choice, paid once for a tool the model already selected.
+- The scorer keeps its deterministic ranking. Top-level input-schema property
+  names join the name-side term set with a small penalty, so queries such as
+  `page id` or `database` find tools through their arguments. The single-term
+  qualification rule stays: a loose hit now costs at most one window, and
+  name matches already sort ahead of description matches.
+- `mcp_call` argument validation includes the tool's input schema in its
+  error text. A model working from a truncated hit recovers with one retry
+  instead of a detail call.
+- Hits and pages are serialized compactly, and the window and page budget
+  are measured on that compact form. Today's pretty-printed visible text
+  inflates Configurator hits by a third at the median and nearly doubles the
+  largest schemas, all of it whitespace the model pays for.
+- Three hard-coded constants: 8 KiB per hit, 64 KiB per page, five names per
+  detail call.
+
+Calibration, measured on the Configurator inventory of 102 tools:
+
+| field | median | p90 | max |
+|---|---|---|---|
+| description | 126 B | 198 B | 292 B |
+| input schema | 247 B | 2.0 KiB | 16.7 KiB |
+| both | 379 B | 2.2 KiB | 16.9 KiB |
+
+As compact hits with server, name, and annotations included, 95 of 102 fit
+whole under 8 KiB; the rest are session and profile schemas that inline
+definition trees. Notion is the mirror image, with long
+descriptions and moderate schemas. Its four descriptions above 4 KiB are the
+expected truncation cases.
 
 ## Acceptance
 
-- The live Notion inventory shows all 41 tools and all four previously shortened
-  descriptions through tool detail.
-- A transcript initially renders a bounded preview and can retrieve the exact
-  complete search result from its CAS reference.
-- Synthetic 10,000-tool and maximum-schema fixtures remain within declared
-  memory, response, and context budgets; pagination cannot loop indefinitely.
-- A natural-language query finds tools from argument metadata and returns a
-  small ranked set; obtaining a full selected definition never requires
-  browsing the entire inventory.
-- Every refusal or partial field identifies the specific bound that applied.
+- Live Notion discovery on the management page shows all 41 tools with every
+  description intact.
+- A transcript entry longer than 4 KiB renders a truncated marker and expands
+  to the exact CAS body.
+- A `mcp_find_tools` search against Notion returns a page at or under 64 KiB
+  of hits. Whole hits carry full schemas, oversized hits carry the truncation
+  note, and a detail call with `names` returns the full definition.
+- A query for an argument name finds the tools that declare it.
+- Browsing a search-exposure server pages to completion, and the cursor never
+  loops.
+- The gateway still rejects a non-exempt response above 2 MiB; the discovery
+  method is exempt.
 
 ## Non-Goals
 
-- Preloading every advertised tool because a model has a large context window.
+- Preloading inventories because a model has a large context window.
+- Pagination or a tool-detail method for management discovery.
+- Truncation metadata such as `originalBytes` on management views.
+- Per-deployment configuration of discovery or search limits.
+- Changing the discovery limits documented in P143.
 - Persisting a management discovery snapshot as execution authority.
-- Accepting unbounded responses or inventories; a 1 GiB catalog remains a hard
-  failure.
+
+## Implementation Slices
+
+### Slice 1 — Management discovery and transcript
+
+- `gateway/http.rs`: add the discovery method to `response_budget_exempt`.
+- `gateway/service/mcp_api.rs`: remove the `DISCOVERY_VIEW_*` constants and
+  the truncation in `mcp_tool_discovery_success`; drop the response-budget
+  projection test. The discoverer's truncation and its test stay.
+- `platform/web`: truncated transcript entries expand through `blobs/read`.
+- P143 Limits section: drop the sentence about the management projection
+  sharing 512 KiB of text.
+
+### Slice 2 — Search result shape
+
+- `worker/mcp.rs` `find_tools`: uniform hit rendering with the 8 KiB window,
+  byte-paged results, `names` mode, compact serialization of the visible
+  text; `validate_search_call` error text carries the schema.
+- `crates/mcp/src/search.rs`: argument-name terms.
+- `gateway/service/mcp_api.rs`: the meta-tool schema gains `names`; the
+  description explains browse, search, and detail.
+- `api-projection`: the transcript display for a detail call names the
+  requested tools.
+- `tests/mcp_live.rs`: update result-shape and pagination assertions; add a
+  detail-mode case and an oversized-hit case against a synthetic fixture.
+- P145 Search Exposure section: point at this document for the result shape.

--- a/docs/roadmap/roadmap.md
+++ b/docs/roadmap/roadmap.md
@@ -2,11 +2,11 @@
 
 ## Work
 - [ ] [P148](p148-scalable-mcp-discovery-and-tool-search.md) — scalable MCP
-  discovery and tool search: replace silent 4 KiB management truncation with
-  paginated summaries plus full tool detail, distinguish CAS-backed transcript
-  previews from source truncation, raise the bounded inventory envelope for
-  enterprise servers, and return small ranked search sets under an aggregate
-  context budget.
+  discovery and tool search: exempt management discovery from the gateway
+  response budget instead of truncating descriptions, expand truncated
+  transcript entries from CAS in the UI, and reshape `mcp_find_tools` into one
+  8 KiB-windowed hit shape with 64 KiB byte-paged results and a `names` mode
+  for full definitions.
 - [ ] [P147](p147-session-checkpoints-and-bounded-reads.md) — session
   checkpoints and bounded reads: keep the event log authoritative while one
   CAS-backed reducer checkpoint per session (advance-only pointer row) makes
@@ -383,10 +383,10 @@ Superseded by [P134](p134-subagents.md); the entries below are history.
 - [ ] Design capability based model for agents
 
 ## MCP
-- [ ] [P148](p148-scalable-mcp-discovery-and-tool-search.md) — preserve large
-  MCP inventories within an explicit safety envelope while management views
-  paginate, transcript previews expand through CAS, and model search retrieves
-  only a small ranked set plus full definitions on demand
+- [ ] [P148](p148-scalable-mcp-discovery-and-tool-search.md) — return complete
+  MCP inventories to management views, expand transcript previews through CAS,
+  and give model search one 8 KiB hit shape, 64 KiB pages, and full
+  definitions by name
 - [x] [P110](p110-universe-owned-mcp-auth.md) — make authentication part of
   each universe-scoped MCP server configuration, remove grant selection and
   grant references from sessions, and resolve the server's current credential

--- a/docs/roadmap/roadmap.md
+++ b/docs/roadmap/roadmap.md
@@ -1,6 +1,12 @@
 # Lightspeed Roadmap
 
 ## Work
+- [ ] [P148](p148-scalable-mcp-discovery-and-tool-search.md) — scalable MCP
+  discovery and tool search: replace silent 4 KiB management truncation with
+  paginated summaries plus full tool detail, distinguish CAS-backed transcript
+  previews from source truncation, raise the bounded inventory envelope for
+  enterprise servers, and return small ranked search sets under an aggregate
+  context budget.
 - [ ] [P147](p147-session-checkpoints-and-bounded-reads.md) — session
   checkpoints and bounded reads: keep the event log authoritative while one
   CAS-backed reducer checkpoint per session (advance-only pointer row) makes
@@ -377,6 +383,10 @@ Superseded by [P134](p134-subagents.md); the entries below are history.
 - [ ] Design capability based model for agents
 
 ## MCP
+- [ ] [P148](p148-scalable-mcp-discovery-and-tool-search.md) — preserve large
+  MCP inventories within an explicit safety envelope while management views
+  paginate, transcript previews expand through CAS, and model search retrieves
+  only a small ranked set plus full definitions on demand
 - [x] [P110](p110-universe-owned-mcp-auth.md) — make authentication part of
   each universe-scoped MCP server configuration, remove grant selection and
   grant references from sessions, and resolve the server's current credential

--- a/platform/web/src/components/session/expandable-content.test.tsx
+++ b/platform/web/src/components/session/expandable-content.test.tsx
@@ -1,0 +1,20 @@
+import { createElement } from "react";
+import { renderToString } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { ExpandableContent } from "./expandable-content";
+
+describe("ExpandableContent", () => {
+  it("renders the bounded preview, marker, and CAS expansion action", () => {
+    const html = renderToString(createElement(ExpandableContent, {
+      text: "bounded preview",
+      truncated: true,
+      contentRef: "sha256:full",
+      loadFullText: async () => "complete body",
+      children: (text: string) => createElement("pre", null, text),
+    }));
+
+    expect(html).toContain("bounded preview");
+    expect(html).toContain("Truncated preview.");
+    expect(html).toContain("Expand full entry");
+  });
+});

--- a/platform/web/src/components/session/expandable-content.tsx
+++ b/platform/web/src/components/session/expandable-content.tsx
@@ -1,0 +1,54 @@
+import { useState, type ReactNode } from "react";
+import { Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export type FullTextLoader = (contentRef: string) => Promise<string>;
+
+export function ExpandableContent({
+  text,
+  truncated = false,
+  contentRef,
+  loadFullText,
+  children,
+}: {
+  text: string;
+  truncated?: boolean;
+  contentRef?: string;
+  loadFullText?: FullTextLoader;
+  children: (text: string) => ReactNode;
+}) {
+  const [fullText, setFullText] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const expandable = truncated && Boolean(contentRef && loadFullText);
+
+  const expand = () => {
+    if (!contentRef || !loadFullText || loading) return;
+    setLoading(true);
+    setError(null);
+    void loadFullText(contentRef)
+      .then(setFullText)
+      .catch((reason: unknown) => {
+        setError(reason instanceof Error ? reason.message : String(reason));
+      })
+      .finally(() => setLoading(false));
+  };
+
+  return (
+    <div className="min-w-0">
+      {children(fullText ?? text)}
+      {truncated && fullText === null && (
+        <div className="mt-1.5 flex items-center gap-2 text-xs text-muted-foreground">
+          <span>Truncated preview.</span>
+          {expandable && (
+            <Button variant="link" size="xs" className="h-auto px-0" disabled={loading} onClick={expand}>
+              {loading && <Loader2 className="animate-spin" />}
+              {loading ? "Loading…" : "Expand full entry"}
+            </Button>
+          )}
+        </div>
+      )}
+      {error && <p className="mt-1 text-xs text-destructive">Could not expand: {error}</p>}
+    </div>
+  );
+}

--- a/platform/web/src/components/session/tool-trace.tsx
+++ b/platform/web/src/components/session/tool-trace.tsx
@@ -27,6 +27,10 @@ import { Separator } from "@/components/ui/separator";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { MarkdownContent } from "@/components/session/markdown-content";
 import {
+  ExpandableContent,
+  type FullTextLoader,
+} from "@/components/session/expandable-content";
+import {
   isFailedToolCall,
   isTerminalToolStatus,
   toolTarget,
@@ -72,7 +76,13 @@ export function ReasoningTrace({ text }: { text: string }) {
   );
 }
 
-export function ToolGroupTrace({ group }: { group: TranscriptToolGroup }) {
+export function ToolGroupTrace({
+  group,
+  loadFullText,
+}: {
+  group: TranscriptToolGroup;
+  loadFullText?: FullTextLoader;
+}) {
   const active = !isTerminalToolStatus(group.status);
   const failedCalls = group.calls.filter(isFailedToolCall).length;
   const [open, setOpen] = useState(false);
@@ -114,7 +124,7 @@ export function ToolGroupTrace({ group }: { group: TranscriptToolGroup }) {
           <Separator />
           <div className="min-w-0 divide-y">
             {group.calls.map((call) => (
-              <ToolCallDetails key={call.callId} call={call} />
+              <ToolCallDetails key={call.callId} call={call} loadFullText={loadFullText} />
             ))}
           </div>
         </CollapsibleContent>
@@ -140,7 +150,13 @@ function ToolActivity({ call }: { call: TranscriptToolCall }) {
   );
 }
 
-function ToolCallDetails({ call }: { call: TranscriptToolCall }) {
+function ToolCallDetails({
+  call,
+  loadFullText,
+}: {
+  call: TranscriptToolCall;
+  loadFullText?: FullTextLoader;
+}) {
   const input = call.argumentsJson ? prettyJson(call.argumentsJson) : null;
   const output = call.error || call.output || null;
   const effects = call.effects?.length ? JSON.stringify(call.effects, null, 2) : null;
@@ -181,7 +197,14 @@ function ToolCallDetails({ call }: { call: TranscriptToolCall }) {
           )}
           {output && (
             <TabsContent value="output" className="min-w-0 max-w-full">
-              <DetailBlock value={output} tone={failed ? "warning" : "default"} />
+              <ExpandableContent
+                text={output}
+                truncated={call.outputTruncated}
+                contentRef={call.outputContentRef}
+                loadFullText={loadFullText}
+              >
+                {(text) => <DetailBlock value={text} tone={failed ? "warning" : "default"} />}
+              </ExpandableContent>
             </TabsContent>
           )}
           {effects && (

--- a/platform/web/src/components/session/transcript-view.tsx
+++ b/platform/web/src/components/session/transcript-view.tsx
@@ -5,6 +5,10 @@ import { Button } from "@/components/ui/button";
 import { Marker, MarkerContent, MarkerIcon } from "@/components/ui/marker";
 import { Message, MessageContent } from "@/components/ui/message";
 import { MarkdownContent } from "@/components/session/markdown-content";
+import {
+  ExpandableContent,
+  type FullTextLoader,
+} from "@/components/session/expandable-content";
 import { ReasoningTrace, ToolGroupTrace } from "@/components/session/tool-trace";
 import {
   type ActiveRun,
@@ -16,21 +20,36 @@ import { cn } from "@/lib/utils";
 /// is a tinted band, assistant output plain rendered text, tool activity
 /// and lifecycle notes are compact marker rows.
 
-export function TranscriptEntryView({ entry }: { entry: TranscriptEntry }) {
+export function TranscriptEntryView({
+  entry,
+  loadFullText,
+}: {
+  entry: TranscriptEntry;
+  loadFullText?: FullTextLoader;
+}) {
   switch (entry.kind) {
     case "message":
-      return entry.role === "user" ? (
-        <UserBand text={entry.text} steering={entry.steering === true} />
-      ) : (
-        <Message>
-          <MessageContent>
-            <Bubble variant="ghost" className="max-w-full">
-              <BubbleContent>
-                <MarkdownContent>{entry.text}</MarkdownContent>
-              </BubbleContent>
-            </Bubble>
-          </MessageContent>
-        </Message>
+      return (
+        <ExpandableContent
+          text={entry.text}
+          truncated={entry.textTruncated}
+          contentRef={entry.contentRef}
+          loadFullText={loadFullText}
+        >
+          {(text) => entry.role === "user" ? (
+            <UserBand text={text} steering={entry.steering === true} />
+          ) : (
+            <Message>
+              <MessageContent>
+                <Bubble variant="ghost" className="max-w-full">
+                  <BubbleContent>
+                    <MarkdownContent>{text}</MarkdownContent>
+                  </BubbleContent>
+                </Bubble>
+              </MessageContent>
+            </Message>
+          )}
+        </ExpandableContent>
       );
     case "system":
       return (
@@ -45,7 +64,7 @@ export function TranscriptEntryView({ entry }: { entry: TranscriptEntry }) {
     case "reasoning":
       return <ReasoningTrace text={entry.text} />;
     case "tool-group":
-      return <ToolGroupTrace group={entry} />;
+      return <ToolGroupTrace group={entry} loadFullText={loadFullText} />;
     case "marker":
       return entry.tone === "error" ? (
         <Marker className="text-destructive">

--- a/platform/web/src/lib/sessions/transcript.test.ts
+++ b/platform/web/src/lib/sessions/transcript.test.ts
@@ -52,6 +52,40 @@ const runView = (
 });
 
 describe("session transcript traces", () => {
+  it("keeps blob references for truncated message and tool-result expansion", () => {
+    const state = applyEvents(emptyTranscript(), [
+      event(1, {
+        type: "contextEntriesApplied",
+        entries: [
+          item("message", { type: "message", role: "assistant" }, {
+            text: "message preview",
+            textTruncated: true,
+          }),
+          item("tool", { type: "toolCall", callId: "call", name: "read_file" }),
+          item("result", { type: "toolResult", callId: "call", isError: false }, {
+            text: "result preview",
+            textTruncated: true,
+          }),
+        ],
+      }),
+    ]);
+
+    expect(state.entries[0]).toMatchObject({
+      kind: "message",
+      contentRef: "sha256:message",
+      text: "message preview",
+      textTruncated: true,
+    });
+    expect(state.entries[1]).toMatchObject({
+      kind: "tool-group",
+      calls: [{
+        output: "result preview",
+        outputContentRef: "sha256:result",
+        outputTruncated: true,
+      }],
+    });
+  });
+
   it("keeps readable reasoning summaries and hides opaque continuation state", () => {
     const state = applyEvents(emptyTranscript(), [
       event(1, {
@@ -460,12 +494,22 @@ describe("session transcript run control", () => {
       }),
     ]);
     expect(state.entries).toEqual([
-      { kind: "message", key: "input", role: "user", text: "do the task", runId: "run_1" },
+      {
+        kind: "message",
+        key: "input",
+        role: "user",
+        text: "do the task",
+        contentRef: "sha256:input",
+        textTruncated: false,
+        runId: "run_1",
+      },
       {
         kind: "message",
         key: "steer",
         role: "user",
         text: "also mention the moon",
+        contentRef: "sha256:steer",
+        textTruncated: false,
         runId: "run_1",
         steering: true,
       },

--- a/platform/web/src/lib/sessions/transcript.ts
+++ b/platform/web/src/lib/sessions/transcript.ts
@@ -15,6 +15,8 @@ export type TranscriptEntry =
       key: string;
       role: "user" | "assistant";
       text: string;
+      contentRef: string;
+      textTruncated: boolean;
       /// The run this entry belongs to, when the engine recorded one.
       runId?: string;
       /// A user message injected into a running run (steering) rather than
@@ -39,6 +41,8 @@ export interface TranscriptToolCall {
   status: ToolItemStatus;
   argumentsJson?: string | null;
   output?: string | null;
+  outputContentRef?: string;
+  outputTruncated?: boolean;
   error?: string | null;
   isError: boolean;
   display?: ToolCallDisplay | null;
@@ -551,6 +555,8 @@ function applyNonToolCallItem(
           key: item.id,
           role: kind.role,
           text: item.text,
+          contentRef: item.contentRef,
+          textTruncated: item.textTruncated === true,
           ...(runId ? { runId } : {}),
           ...(source?.type === "steering" ? { steering: true } : {}),
         });
@@ -616,6 +622,8 @@ function applyNonToolCallItem(
         ...call,
         status: item.display?.status ?? (isError ? "failed" : "succeeded"),
         output: item.display?.output ?? item.text,
+        outputContentRef: item.contentRef,
+        outputTruncated: item.textTruncated === true,
         error: item.display?.error ?? (isError ? item.display?.output ?? item.text : null),
         isError,
       }));

--- a/platform/web/src/pages/SessionsPage.tsx
+++ b/platform/web/src/pages/SessionsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState, type FormEvent } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type FormEvent } from "react";
 import {
   type InfiniteData,
   useInfiniteQuery,
@@ -10,6 +10,7 @@ import { NavLink, useNavigate, useParams } from "react-router-dom";
 import { Archive, ArrowLeft, Check, Copy, ListFilter, LoaderCircle, Plus, ShieldCheck, SlidersHorizontal, Trash2 } from "lucide-react";
 import {
   api,
+  type BlobContent,
   type Environment,
   type InlineProfile,
   type ProfileDocument,
@@ -779,6 +780,18 @@ export function SessionDetail({
   } | null>(null);
 
   const entries = tail.transcript.entries;
+  const loadFullText = useCallback(
+    async (contentRef: string) => {
+      const blob = await api<BlobContent>(
+        "GET",
+        `/api/v1/universes/${universeId}/blobs/${encodeURIComponent(contentRef)}`,
+      );
+      const binary = atob(blob.bytesBase64);
+      const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
+      return new TextDecoder().decode(bytes);
+    },
+    [universeId],
+  );
   const activeRun = tail.transcript.activeRun;
   const queuedRuns = tail.transcript.queuedRuns;
   const runRevision = tail.transcript.runRevision;
@@ -1399,7 +1412,7 @@ export function SessionDetail({
                   key={entry.key}
                   messageId={entry.key}
                 >
-                  <TranscriptEntryView entry={entry} />
+                  <TranscriptEntryView entry={entry} loadFullText={loadFullText} />
                 </MessageScrollerItem>
               ))}
               {pendingInTranscript.map((message) => (


### PR DESCRIPTION
## Summary
- return the discoverer-retained MCP inventory through management APIs without gateway projection truncation
- add expandable CAS-backed transcript previews in the web UI
- make `mcp_find_tools` return uniform 8 KiB hits in compact 64 KiB pages, with argument-name search and full-definition `names` mode
- include schemas in `mcp_call` validation errors and improve transcript projections
- update roadmap documentation and live MCP matrix coverage

## Verification
- `cargo test`
- `cargo test -p temporal-server --test mcp_live --no-run`
- `npm run typecheck --workspace @lightspeed/platform-web`
- `npm run test --workspace @lightspeed/platform-web`
- `npm run check:generated`
- `git diff --check`

Credentialed/live tests were not run.