### PR TITLE
Fix compaction threshold persistence in configuration editors

### DIFF
--- a/clients/typescript/schema/api.schema.json
+++ b/clients/typescript/schema/api.schema.json
@@ -7031,7 +7031,7 @@
         },
         {
           "properties": {
-            "compact_threshold_tokens": {
+            "compactThresholdTokens": {
               "format": "uint32",
               "minimum": 0,
               "type": [
@@ -7051,7 +7051,7 @@
         },
         {
           "properties": {
-            "compact_threshold_tokens": {
+            "compactThresholdTokens": {
               "format": "uint32",
               "minimum": 0,
               "type": [
@@ -7063,7 +7063,7 @@
               "const": "providerStandalone",
               "type": "string"
             },
-            "target_tokens": {
+            "targetTokens": {
               "format": "uint32",
               "minimum": 0,
               "type": [

--- a/clients/typescript/src/generated/types.ts
+++ b/clients/typescript/src/generated/types.ts
@@ -270,13 +270,13 @@ export type CompactionPolicy =
       mode: "disabled";
     }
   | {
-      compact_threshold_tokens?: number | null;
+      compactThresholdTokens?: number | null;
       mode: "providerTriggered";
     }
   | {
-      compact_threshold_tokens?: number | null;
+      compactThresholdTokens?: number | null;
       mode: "providerStandalone";
-      target_tokens?: number | null;
+      targetTokens?: number | null;
     };
 /**
  * This interface was referenced by `LightspeedAgentAPI`'s JSON-Schema

--- a/crates/api/contract/api.schema.json
+++ b/crates/api/contract/api.schema.json
@@ -7031,7 +7031,7 @@
         },
         {
           "properties": {
-            "compact_threshold_tokens": {
+            "compactThresholdTokens": {
               "format": "uint32",
               "minimum": 0,
               "type": [
@@ -7051,7 +7051,7 @@
         },
         {
           "properties": {
-            "compact_threshold_tokens": {
+            "compactThresholdTokens": {
               "format": "uint32",
               "minimum": 0,
               "type": [
@@ -7063,7 +7063,7 @@
               "const": "providerStandalone",
               "type": "string"
             },
-            "target_tokens": {
+            "targetTokens": {
               "format": "uint32",
               "minimum": 0,
               "type": [

--- a/crates/api/contract/openrpc.json
+++ b/crates/api/contract/openrpc.json
@@ -7031,7 +7031,7 @@
           },
           {
             "properties": {
-              "compact_threshold_tokens": {
+              "compactThresholdTokens": {
                 "format": "uint32",
                 "minimum": 0,
                 "type": [
@@ -7051,7 +7051,7 @@
           },
           {
             "properties": {
-              "compact_threshold_tokens": {
+              "compactThresholdTokens": {
                 "format": "uint32",
                 "minimum": 0,
                 "type": [
@@ -7063,7 +7063,7 @@
                 "const": "providerStandalone",
                 "type": "string"
               },
-              "target_tokens": {
+              "targetTokens": {
                 "format": "uint32",
                 "minimum": 0,
                 "type": [

--- a/crates/api/src/sessions.rs
+++ b/crates/api/src/sessions.rs
@@ -359,17 +359,33 @@ pub struct ContextConfig {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", tag = "mode")]
+#[serde(
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase",
+    tag = "mode"
+)]
 pub enum CompactionPolicy {
     Disabled,
     ProviderTriggered {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[serde(
+            default,
+            alias = "compact_threshold_tokens",
+            skip_serializing_if = "Option::is_none"
+        )]
         compact_threshold_tokens: Option<u32>,
     },
     ProviderStandalone {
-        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[serde(
+            default,
+            alias = "compact_threshold_tokens",
+            skip_serializing_if = "Option::is_none"
+        )]
         compact_threshold_tokens: Option<u32>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[serde(
+            default,
+            alias = "target_tokens",
+            skip_serializing_if = "Option::is_none"
+        )]
         target_tokens: Option<u32>,
     },
 }
@@ -1460,4 +1476,47 @@ pub struct ToolCallEventView {
     pub arguments: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub display: Option<ToolCallDisplayView>,
+}
+
+#[cfg(test)]
+mod compaction_wire_tests {
+    use super::CompactionPolicy;
+    use serde_json::json;
+
+    #[test]
+    fn editor_compaction_fields_round_trip() {
+        for (value, expected) in [
+            (
+                json!({"mode": "providerTriggered", "compactThresholdTokens": 250000}),
+                CompactionPolicy::ProviderTriggered {
+                    compact_threshold_tokens: Some(250000),
+                },
+            ),
+            (
+                json!({"mode": "providerStandalone", "compactThresholdTokens": 250000, "targetTokens": 100000}),
+                CompactionPolicy::ProviderStandalone {
+                    compact_threshold_tokens: Some(250000),
+                    target_tokens: Some(100000),
+                },
+            ),
+        ] {
+            let decoded: CompactionPolicy = serde_json::from_value(value.clone()).unwrap();
+            assert_eq!(decoded, expected);
+            assert_eq!(serde_json::to_value(decoded).unwrap(), value);
+        }
+    }
+
+    #[test]
+    fn legacy_compaction_fields_remain_readable() {
+        for mode in ["providerTriggered", "providerStandalone"] {
+            let mut legacy = json!({"mode": mode, "compact_threshold_tokens": 250000});
+            let mut canonical = json!({"mode": mode, "compactThresholdTokens": 250000});
+            if mode == "providerStandalone" {
+                legacy["target_tokens"] = json!(100000);
+                canonical["targetTokens"] = json!(100000);
+            }
+            let decoded: CompactionPolicy = serde_json::from_value(legacy).unwrap();
+            assert_eq!(serde_json::to_value(decoded).unwrap(), canonical);
+        }
+    }
 }

--- a/crates/api/tests/schema_artifacts.rs
+++ b/crates/api/tests/schema_artifacts.rs
@@ -129,3 +129,30 @@ fn committed_schema_artifacts_are_current() {
         "crates/api/contract/api-reference.md is stale; run `cargo run -p api --bin export-schema` and commit the result"
     );
 }
+
+#[test]
+fn compaction_schema_exposes_editor_field_names() {
+    let bundle = committed("api.schema.json");
+    let policy = &bundle["definitions"]["CompactionPolicy"];
+    let variants = policy["oneOf"].as_array().expect("compaction variants");
+    let mut thresholds = 0;
+    let mut targets = 0;
+    for variant in variants {
+        let properties = variant["properties"]
+            .as_object()
+            .expect("variant properties");
+        assert!(!properties.contains_key("compact_threshold_tokens"));
+        assert!(!properties.contains_key("target_tokens"));
+        thresholds += usize::from(properties.contains_key("compactThresholdTokens"));
+        targets += usize::from(properties.contains_key("targetTokens"));
+    }
+    assert_eq!(thresholds, 2);
+    assert_eq!(targets, 1);
+    assert_validates(
+        &bundle,
+        "CompactionPolicy",
+        &json!({
+            "mode": "providerStandalone", "compactThresholdTokens": 250000, "targetTokens": 100000
+        }),
+    );
+}

--- a/platform/configurator-mcp/src/generated/tools.ts
+++ b/platform/configurator-mcp/src/generated/tools.ts
@@ -97,7 +97,7 @@ export const GENERATED_TOOLS: readonly GeneratedToolDescriptor[] = [
             },
             {
               "properties": {
-                "compact_threshold_tokens": {
+                "compactThresholdTokens": {
                   "format": "uint32",
                   "minimum": 0,
                   "type": [
@@ -117,7 +117,7 @@ export const GENERATED_TOOLS: readonly GeneratedToolDescriptor[] = [
             },
             {
               "properties": {
-                "compact_threshold_tokens": {
+                "compactThresholdTokens": {
                   "format": "uint32",
                   "minimum": 0,
                   "type": [
@@ -129,7 +129,7 @@ export const GENERATED_TOOLS: readonly GeneratedToolDescriptor[] = [
                   "const": "providerStandalone",
                   "type": "string"
                 },
-                "target_tokens": {
+                "targetTokens": {
                   "format": "uint32",
                   "minimum": 0,
                   "type": [
@@ -1408,7 +1408,7 @@ export const GENERATED_TOOLS: readonly GeneratedToolDescriptor[] = [
             },
             {
               "properties": {
-                "compact_threshold_tokens": {
+                "compactThresholdTokens": {
                   "format": "uint32",
                   "minimum": 0,
                   "type": [
@@ -1428,7 +1428,7 @@ export const GENERATED_TOOLS: readonly GeneratedToolDescriptor[] = [
             },
             {
               "properties": {
-                "compact_threshold_tokens": {
+                "compactThresholdTokens": {
                   "format": "uint32",
                   "minimum": 0,
                   "type": [
@@ -1440,7 +1440,7 @@ export const GENERATED_TOOLS: readonly GeneratedToolDescriptor[] = [
                   "const": "providerStandalone",
                   "type": "string"
                 },
-                "target_tokens": {
+                "targetTokens": {
                   "format": "uint32",
                   "minimum": 0,
                   "type": [
@@ -3366,7 +3366,7 @@ export const GENERATED_TOOLS: readonly GeneratedToolDescriptor[] = [
             },
             {
               "properties": {
-                "compact_threshold_tokens": {
+                "compactThresholdTokens": {
                   "format": "uint32",
                   "minimum": 0,
                   "type": [
@@ -3386,7 +3386,7 @@ export const GENERATED_TOOLS: readonly GeneratedToolDescriptor[] = [
             },
             {
               "properties": {
-                "compact_threshold_tokens": {
+                "compactThresholdTokens": {
                   "format": "uint32",
                   "minimum": 0,
                   "type": [
@@ -3398,7 +3398,7 @@ export const GENERATED_TOOLS: readonly GeneratedToolDescriptor[] = [
                   "const": "providerStandalone",
                   "type": "string"
                 },
-                "target_tokens": {
+                "targetTokens": {
                   "format": "uint32",
                   "minimum": 0,
                   "type": [
@@ -5346,7 +5346,7 @@ export const GENERATED_TOOLS: readonly GeneratedToolDescriptor[] = [
             },
             {
               "properties": {
-                "compact_threshold_tokens": {
+                "compactThresholdTokens": {
                   "format": "uint32",
                   "minimum": 0,
                   "type": [
@@ -5366,7 +5366,7 @@ export const GENERATED_TOOLS: readonly GeneratedToolDescriptor[] = [
             },
             {
               "properties": {
-                "compact_threshold_tokens": {
+                "compactThresholdTokens": {
                   "format": "uint32",
                   "minimum": 0,
                   "type": [
@@ -5378,7 +5378,7 @@ export const GENERATED_TOOLS: readonly GeneratedToolDescriptor[] = [
                   "const": "providerStandalone",
                   "type": "string"
                 },
-                "target_tokens": {
+                "targetTokens": {
                   "format": "uint32",
                   "minimum": 0,
                   "type": [
@@ -6537,7 +6537,7 @@ export const GENERATED_TOOLS: readonly GeneratedToolDescriptor[] = [
             },
             {
               "properties": {
-                "compact_threshold_tokens": {
+                "compactThresholdTokens": {
                   "format": "uint32",
                   "minimum": 0,
                   "type": [
@@ -6557,7 +6557,7 @@ export const GENERATED_TOOLS: readonly GeneratedToolDescriptor[] = [
             },
             {
               "properties": {
-                "compact_threshold_tokens": {
+                "compactThresholdTokens": {
                   "format": "uint32",
                   "minimum": 0,
                   "type": [
@@ -6569,7 +6569,7 @@ export const GENERATED_TOOLS: readonly GeneratedToolDescriptor[] = [
                   "const": "providerStandalone",
                   "type": "string"
                 },
-                "target_tokens": {
+                "targetTokens": {
                   "format": "uint32",
                   "minimum": 0,
                   "type": [

--- a/platform/web/src/lib/profile-config-reference.ts
+++ b/platform/web/src/lib/profile-config-reference.ts
@@ -8,8 +8,8 @@ export const PROFILE_CONFIG_REFERENCE = `// Every field is optional — omit any
   "context": {
     "compaction": // one of:
       { "mode": "disabled" } |
-      { "compact_threshold_tokens": 0, "mode": "providerTriggered" } |
-      { "compact_threshold_tokens": 0, "mode": "providerStandalone", "target_tokens": 0 },
+      { "compactThresholdTokens": 0, "mode": "providerTriggered" } |
+      { "compactThresholdTokens": 0, "mode": "providerStandalone", "targetTokens": 0 },
   },
   // Capability grants. An absent feature is not granted; \`{}\` grants it with defaults. Every block carries a behavior \`version\` that pins semantics.
   "features": {


### PR DESCRIPTION
Saving a compaction threshold in profile, session, or bot settings silently discarded the value: the editors sent `compactThresholdTokens`, while the API expected `compact_threshold_tokens`. Standalone compaction's `targetTokens` had the same mismatch.

Make the API serialize and deserialize these fields in camelCase, while retaining snake_case input aliases for existing clients. Regenerate the API schemas, TypeScript client, Configurator tools, and profile reference. Add regression tests for both modes, legacy inputs, and schema field names.

Validation:
- `cargo test -p api`: 91 tests passed.
- `npm run typecheck` and `npm run test`: passed; 268 JavaScript tests.
- `npm run build`: production and demo builds passed.
- `npm run check:generated`: passed after committing generated artifacts.
- `git diff --check`: passed.

The branch starts from `origin/main`. No production settings were changed. Thresholds previously discarded by the API must be entered again after deployment.
