### PR TITLE
Prepare Lightspeed v0.2.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -685,7 +685,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "api",
@@ -1238,7 +1238,7 @@ dependencies = [
 
 [[package]]
 name = "environment-daemon"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "api",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "environment-provider-incus"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3719,7 +3719,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "release-info"
-version = "0.1.0"
+version = "0.2.0"
 
 [[package]]
 name = "reqwest"
@@ -4752,7 +4752,7 @@ dependencies = [
 
 [[package]]
 name = "temporal-server"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "api",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/environment-daemon/Cargo.toml
+++ b/crates/environment-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "environment-daemon"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/environment-provider-incus/Cargo.toml
+++ b/crates/environment-provider-incus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "environment-provider-incus"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/release-info/Cargo.toml
+++ b/crates/release-info/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
 name = "release-info"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 build = "build.rs"

--- a/crates/temporal-server/Cargo.toml
+++ b/crates/temporal-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "temporal-server"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 [dependencies]

--- a/docs/documentation/deployment/self-hosting.md
+++ b/docs/documentation/deployment/self-hosting.md
@@ -45,12 +45,12 @@ installation.
 ## Download one release
 
 Choose a tag from [GitHub Releases](https://github.com/smartcomputer-ai/lightspeed/releases).
-The example below uses `v0.1.0`; replace it with the release you intend to
+The example below uses `v0.2.0`; replace it with the release you intend to
 install. Download its manifest into a directory you will keep with the
 deployment record:
 
 ```bash
-LIGHTSPEED_RELEASE_TAG=v0.1.0
+LIGHTSPEED_RELEASE_TAG=v0.2.0
 mkdir -p "$HOME/lightspeed-releases/$LIGHTSPEED_RELEASE_TAG"
 cd "$HOME/lightspeed-releases/$LIGHTSPEED_RELEASE_TAG"
 curl --fail --location --output release-manifest.json \

--- a/release/metadata.env
+++ b/release/metadata.env
@@ -4,7 +4,7 @@ LIGHTSPEED_RELEASE_TARGET=x86_64-unknown-linux-gnu
 # The environment daemon alone is published as a static binary so it runs on
 # any Linux image regardless of its glibc.
 LIGHTSPEED_ENVD_TARGET=x86_64-unknown-linux-musl
-LIGHTSPEED_PRODUCT_VERSION=0.1.0
+LIGHTSPEED_PRODUCT_VERSION=0.2.0
 LIGHTSPEED_RELEASE_RUST_VERSION=1.97.1
 LIGHTSPEED_RELEASE_BUILD_BASE_IMAGE=rust:1.97.1-bookworm@sha256:0e2bcaef56d041a486784e54104a81aebe0da44bd03019bd70bc0401e42e4a97
 LIGHTSPEED_API_PROTOCOL_VERSION=lightspeed.agent.api.v1

--- a/release/notes/v0.2.0.md
+++ b/release/notes/v0.2.0.md
@@ -1,0 +1,44 @@
+Lightspeed v0.2.0 includes all changes merged since v0.1.0: outbound environment registration, daemon distribution and upgrades, broader MCP support, session metadata and retention, shared content references, a faster management UI, and the product manual.
+
+**Upgrade compatibility**
+
+This release contains breaking API and persisted-state changes. The runtime PostgreSQL schema was consolidated from the v0.1.0 migration history into nine domain migrations, and session/workflow content and builtin-tool registrations changed. There is no supported in-place migration from v0.1.0 runtime data and active workflow state. Use a fresh runtime schema and migration ledger with fresh session/workflow state, or establish a separately validated migration before adopting this release. Preserve valuable existing data; do not edit migration ledger entries to force startup.
+
+Deploy components from one release manifest and update generated clients together. `blobs/content/read` was removed in favor of the shared content-reference APIs. Outbound environment daemons and the gateway must agree on environment protocol version 2. The Platform schema remains at revision 1. See [Upgrades and recovery](https://github.com/smartcomputer-ai/lightspeed/blob/v0.2.0/docs/documentation/deployment/upgrades-and-recovery.md) for compatibility and recovery procedures.
+
+**Environments and daemon distribution**
+
+- Machines behind NAT, Kubernetes pods, and other remote compute can register through outbound daemon connections using universe-scoped registration keys and persistent Ed25519 identities. Keys control identity mode, expiry, environment limits, and disconnect grace. The CLI and Platform support creating, listing, and revoking keys and inspecting registered environments.
+- The `environment-gateway` runtime role owns daemon registration, worker routes, and environment reconciliation. Registered environments expose their groups, reconnect state, and last-seen information; ephemeral environments close after their configured disconnect grace.
+- The Linux amd64 daemon is now a static musl binary. Releases include `envd.json` discovery metadata and verified build identity. `lightspeed-envd upgrade` verifies and installs the deployment-selected build; optional automatic upgrades respond to protocol mismatches while retaining daemon identity.
+- Daemon fixes preserve one contiguous omitted-output gap on uneven pipe reads and close an upgrade candidate before executing it.
+
+**MCP and model tools**
+
+- MCP discovery supports larger enterprise inventories and oversized optional descriptions while retaining validation of tool names and schemas. Management views expose the retained inventory; tool search supports argument-name matching, names-only results, and bounded result pages. Tool validation errors include the relevant schema.
+- Native MCP calls work in mixed batches with managed workflow tools and `await`, including approval-gated calls alongside ungated siblings.
+- Builtin tools resolve model-facing names, schemas, and argument adapters for each provider request from compact internal identities. Provider-native calls remain available for transcript replay.
+- Anthropic hosted web search and fetch include configuration controls, provider lowering, replay, and citation projection. Model-list caching reduces repeated provider discovery.
+
+**Sessions, content, and retention**
+
+- Sessions support metadata, containment filters, profile defaults, and close-based retention. Session and bot settings share profile and trigger controls, including lightweight existing-environment and no-environment overrides.
+- Context entries, run outputs, and public projections share `ContentRef` descriptors and explicit provenance. Messages and visible reasoning expose complete text; detailed run views expose durable output descriptors. Audio transcripts retain source-audio provenance.
+- Content-addressed storage collection protects committed references against concurrent attachment and reupload, follows nested content edges, and uses distinct physical object keys. A deployment-wide collector runs bounded, resumable passes; operators also have the `cas-sweep` CLI.
+
+**Platform and transcript improvements**
+
+- Faster session loading, incremental history loading, reduced transcript flicker, clearer tool traces, run statistics, and connection-timeout and origin-validation fixes.
+- Unsent composer drafts persist locally per universe and session, including bot conversations. Sending, queueing, or steering resumes following the transcript bottom.
+- Provider-native compaction appears as a muted transcript marker. Compaction thresholds now persist correctly in profile, session, and bot editors; camelCase fields retain snake_case input aliases. Previously discarded threshold values must be entered again.
+- Session lists add lifecycle and metadata filters, per-universe preferences, configurable metadata columns, compact rows, and consistent lineage and identity controls. Profiles can be copied, and MCP creation and editing have clearer progress and tool-selection controls.
+- Updated demo fixtures and regression coverage accompany these changes, including integration-link URL encoding.
+
+**Documentation and release artifacts**
+
+- A product manual covers getting started, everyday use, environments, deployment, integrations, architecture, and development. Existing references and repository links were consolidated around the manual.
+- The Astro Starlight documentation site includes search, responsive navigation, light/dark themes, diagrams, screenshots, generated API and workflow references, per-page Markdown exports, and `llms.txt`. The hosted manual is available at [ls.bot/docs](https://ls.bot/docs/).
+- Snapshots and tagged releases package the static documentation archive alongside the demo and executable archives. The release manifest, checksums, OCI bundles, and build provenance include the documentation artifact.
+- Documentation CI validates adapters, links, anchors, assets, search, and the static build. The tagged-release workflow tests and builds the exact tagged source before publishing component images, Linux archives, the TypeScript client, checksums, and an SBOM.
+
+[Full changelog: v0.1.0...v0.2.0](https://github.com/smartcomputer-ai/lightspeed/compare/v0.1.0...v0.2.0)

--- a/release/notes/v0.2.0.md
+++ b/release/notes/v0.2.0.md
@@ -31,7 +31,7 @@ Lightspeed v0.2.0 includes all changes merged since v0.1.0: outbound environment
 **Documentation and release artifacts**
 
 - A product manual covers getting started, everyday use, environments, deployment, integrations, architecture, and development. Existing references and repository links were consolidated around the manual.
-- The Astro Starlight documentation site includes search, responsive navigation, light/dark themes, diagrams, screenshots, generated API and workflow references, per-page Markdown exports, and `llms.txt`. The hosted manual is available at [ls.bot/docs](https://ls.bot/docs/).
+- The Astro Starlight documentation site includes search, responsive navigation, light/dark themes, diagrams, screenshots, generated API and workflow references, per-page Markdown exports, and `llms.txt`. The hosted manual is available at [Lightspeed documentation](https://ls.bot/docs/).
 - Snapshots and tagged releases package the static documentation archive alongside the demo and executable archives. The release manifest, checksums, OCI bundles, and build provenance include the documentation artifact.
 - Documentation CI validates adapters, links, anchors, assets, search, and the static build. The tagged-release workflow tests and builds the exact tagged source before publishing component images, Linux archives, the TypeScript client, checksums, and an SBOM.
 

--- a/release/notes/v0.2.0.md
+++ b/release/notes/v0.2.0.md
@@ -1,11 +1,5 @@
 Lightspeed v0.2.0 includes all changes merged since v0.1.0: outbound environment registration, daemon distribution and upgrades, broader MCP support, session metadata and retention, shared content references, a faster management UI, and the product manual.
 
-**Upgrade compatibility**
-
-This release contains breaking API and persisted-state changes. The runtime PostgreSQL schema was consolidated from the v0.1.0 migration history into nine domain migrations, and session/workflow content and builtin-tool registrations changed. There is no supported in-place migration from v0.1.0 runtime data and active workflow state. Use a fresh runtime schema and migration ledger with fresh session/workflow state, or establish a separately validated migration before adopting this release. Preserve valuable existing data; do not edit migration ledger entries to force startup.
-
-Deploy components from one release manifest and update generated clients together. `blobs/content/read` was removed in favor of the shared content-reference APIs. Outbound environment daemons and the gateway must agree on environment protocol version 2. The Platform schema remains at revision 1. See [Upgrades and recovery](https://github.com/smartcomputer-ai/lightspeed/blob/v0.2.0/docs/documentation/deployment/upgrades-and-recovery.md) for compatibility and recovery procedures.
-
 **Environments and daemon distribution**
 
 - Machines behind NAT, Kubernetes pods, and other remote compute can register through outbound daemon connections using universe-scoped registration keys and persistent Ed25519 identities. Keys control identity mode, expiry, environment limits, and disconnect grace. The CLI and Platform support creating, listing, and revoking keys and inspecting registered environments.
@@ -30,7 +24,7 @@ Deploy components from one release manifest and update generated clients togethe
 
 - Faster session loading, incremental history loading, reduced transcript flicker, clearer tool traces, run statistics, and connection-timeout and origin-validation fixes.
 - Unsent composer drafts persist locally per universe and session, including bot conversations. Sending, queueing, or steering resumes following the transcript bottom.
-- Provider-native compaction appears as a muted transcript marker. Compaction thresholds now persist correctly in profile, session, and bot editors; camelCase fields retain snake_case input aliases. Previously discarded threshold values must be entered again.
+- Provider-native compaction appears as a muted transcript marker. Compaction thresholds now persist correctly in profile, session, and bot editors; camelCase fields retain snake_case input aliases.
 - Session lists add lifecycle and metadata filters, per-universe preferences, configurable metadata columns, compact rows, and consistent lineage and identity controls. Profiles can be copied, and MCP creation and editing have clearer progress and tool-selection controls.
 - Updated demo fixtures and regression coverage accompany these changes, including integration-link URL encoding.
 


### PR DESCRIPTION
Prepare the next official Lightspeed release from main, including all changes since v0.1.0. Set the product and executable versions to 0.2.0, update the matching Cargo lock entries, and add release notes covering environments, MCP and model tools, sessions and retention, Platform UX, and the new documentation site.

Validation: release metadata verification, release-info build, six release-packaging tests, and git diff checks pass locally. The required CI gate must pass before merge; the annotated v0.2.0 tag will then run the official test, build, and publication workflow.
