### PR TITLE
Fix envd musl build and simplify OS operations with Rustix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1260,6 +1260,7 @@ dependencies = [
  "rand 0.8.6",
  "release-info",
  "reqwest 0.13.4",
+ "rustix 1.1.3",
  "rustls",
  "rustls-pki-types",
  "serde",

--- a/crates/environment-daemon/Cargo.toml
+++ b/crates/environment-daemon/Cargo.toml
@@ -33,6 +33,9 @@ rustls-pki-types = { version = "1", features = ["std"] }
 webpki-roots = "1.0"
 
 [target.'cfg(unix)'.dependencies]
+rustix = { version = "1", features = ["fs", "process"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
 libc = "0.2"
 
 [dev-dependencies]

--- a/crates/environment-daemon/src/filesystem/backend/unix.rs
+++ b/crates/environment-daemon/src/filesystem/backend/unix.rs
@@ -2,12 +2,11 @@ use std::{
     ffi::{CStr, CString},
     fs::{File, Metadata},
     io,
-    os::{
-        fd::{AsRawFd, FromRawFd, IntoRawFd},
-        unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt},
-    },
+    os::unix::fs::{MetadataExt, PermissionsExt},
     path::{Component, Path},
 };
+
+use rustix::fs::{self, AtFlags, FileType, Mode, OFlags};
 
 pub struct Directory(File);
 #[derive(Clone, Debug)]
@@ -37,14 +36,6 @@ impl Observation {
 fn c(name: &str) -> io::Result<CString> {
     CString::new(name).map_err(|_| io::Error::from(io::ErrorKind::InvalidInput))
 }
-fn owned(fd: i32) -> io::Result<File> {
-    if fd < 0 {
-        Err(io::Error::last_os_error())
-    } else {
-        // SAFETY: successful calls return one newly owned descriptor.
-        Ok(unsafe { File::from_raw_fd(fd) })
-    }
-}
 fn check(meta: Metadata) -> io::Result<Observation> {
     if meta.is_file() || meta.is_dir() {
         Ok(Observation(meta))
@@ -66,62 +57,39 @@ pub fn set_executable(file: &File, executable: bool) -> io::Result<()> {
     }))
 }
 /// Streaming directory enumeration; cleanup never collects an entire retired tree.
-struct Entries(*mut libc::DIR);
-impl Drop for Entries {
-    fn drop(&mut self) {
-        unsafe {
-            libc::closedir(self.0);
-        }
-    }
-}
+struct Entries(fs::Dir);
 impl Iterator for Entries {
     type Item = io::Result<CString>;
     fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            #[cfg(target_os = "linux")]
-            unsafe {
-                *libc::__errno_location() = 0;
+        self.0.find_map(|entry| match entry {
+            Ok(entry) => {
+                let name = entry.file_name();
+                if name.to_bytes() == b"." || name.to_bytes() == b".." {
+                    None
+                } else {
+                    Some(Ok(name.to_owned()))
+                }
             }
-            #[cfg(target_os = "macos")]
-            unsafe {
-                *libc::__error() = 0;
-            }
-            let entry = unsafe { libc::readdir(self.0) };
-            if entry.is_null() {
-                let error = io::Error::last_os_error();
-                return (error.raw_os_error() != Some(0)).then_some(Err(error));
-            }
-            let name = unsafe { CStr::from_ptr((*entry).d_name.as_ptr()) };
-            if name.to_bytes() == b"." || name.to_bytes() == b".." {
-                continue;
-            }
-            return Some(Ok(name.to_owned()));
-        }
+            Err(error) => Some(Err(error.into())),
+        })
     }
 }
 fn entries(file: &File) -> io::Result<Entries> {
-    let dot = c(".")?;
-    let fd = owned(unsafe {
-        libc::openat(
-            file.as_raw_fd(),
-            dot.as_ptr(),
-            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC,
-        )
-    })?
-    .into_raw_fd();
-    let stream = unsafe { libc::fdopendir(fd) };
-    if stream.is_null() {
-        let error = io::Error::last_os_error();
-        unsafe {
-            libc::close(fd);
-        }
-        return Err(error);
-    }
-    Ok(Entries(stream))
+    // Open a separate description so enumeration never shares the caller's offset.
+    let fd = fs::openat(
+        file,
+        ".",
+        OFlags::RDONLY | OFlags::DIRECTORY | OFlags::CLOEXEC,
+        Mode::empty(),
+    )?;
+    Ok(Entries(fs::Dir::new(fd)?))
 }
 
 pub fn is_path_violation(error: &io::Error) -> bool {
-    matches!(error.raw_os_error(), Some(libc::ELOOP | libc::ENOTDIR))
+    matches!(
+        rustix::io::Errno::from_io_error(error),
+        Some(rustix::io::Errno::LOOP | rustix::io::Errno::NOTDIR)
+    )
 }
 pub fn create_private_directory(path: &Path) -> io::Result<()> {
     use std::os::unix::fs::DirBuilderExt;
@@ -140,10 +108,12 @@ impl Directory {
         // administrator-owned anchor once; user selections are always opened relative to it.
         let root = root.canonicalize()?;
         let mut dir = Self(
-            std::fs::OpenOptions::new()
-                .read(true)
-                .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
-                .open("/")?,
+            fs::open(
+                "/",
+                OFlags::RDONLY | OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+                Mode::empty(),
+            )?
+            .into(),
         );
         for part in root.components() {
             if let Component::Normal(name) = part {
@@ -162,18 +132,18 @@ impl Directory {
         Ok(Self(self.0.try_clone()?))
     }
     pub fn child(&self, name: &str) -> io::Result<Self> {
-        self.child_name(&c(name)?)
+        self.child_name(name)
     }
-    fn child_name(&self, name: &CStr) -> io::Result<Self> {
-        // SAFETY: valid descriptor and NUL-terminated name. Never follow a symlink.
-        let file = owned(unsafe {
-            libc::openat(
-                self.0.as_raw_fd(),
-                name.as_ptr(),
-                libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
-            )
-        })?;
-        Ok(Self(file))
+    fn child_name(&self, name: impl rustix::path::Arg) -> io::Result<Self> {
+        Ok(Self(
+            fs::openat(
+                &self.0,
+                name,
+                OFlags::RDONLY | OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+                Mode::empty(),
+            )?
+            .into(),
+        ))
     }
     pub fn parent(&self, path: &str) -> io::Result<(Self, String)> {
         self.parent_with_creation(path, false)
@@ -215,52 +185,40 @@ impl Directory {
     }
     fn open_kind(&self, path: &str, metadata_only: bool) -> io::Result<File> {
         let (dir, name) = self.parent(path)?;
-        let name = c(&name)?;
         #[cfg(target_os = "linux")]
         let access = if metadata_only {
-            libc::O_PATH
+            OFlags::PATH
         } else {
-            libc::O_RDONLY
+            OFlags::RDONLY
         };
         #[cfg(target_os = "macos")]
         let access = if metadata_only {
-            libc::O_EVTONLY
+            // Rustix does not name the macOS metadata-only flag.
+            OFlags::from_bits_retain(libc::O_EVTONLY as u32)
         } else {
-            libc::O_RDONLY
+            OFlags::RDONLY
         };
-        let file = owned(unsafe {
-            libc::openat(
-                dir.0.as_raw_fd(),
-                name.as_ptr(),
-                access | libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_CLOEXEC,
-            )
-        })?;
+        let file = fs::openat(
+            &dir.0,
+            &name,
+            access | OFlags::NOFOLLOW | OFlags::NONBLOCK | OFlags::CLOEXEC,
+            Mode::empty(),
+        )?
+        .into();
         observe(&file)?;
         Ok(file)
     }
     /// Inspect replacement targets without requiring read permission on their content.
     pub fn target_exists(&self, name: &str) -> io::Result<bool> {
-        let name = c(name)?;
-        let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
-        let result = unsafe {
-            libc::fstatat(
-                self.0.as_raw_fd(),
-                name.as_ptr(),
-                stat.as_mut_ptr(),
-                libc::AT_SYMLINK_NOFOLLOW,
-            )
+        let stat = match fs::statat(&self.0, name, AtFlags::SYMLINK_NOFOLLOW) {
+            Ok(stat) => stat,
+            Err(rustix::io::Errno::NOENT) => return Ok(false),
+            Err(error) => return Err(error.into()),
         };
-        if result < 0 {
-            let error = io::Error::last_os_error();
-            return if error.kind() == io::ErrorKind::NotFound {
-                Ok(false)
-            } else {
-                Err(error)
-            };
-        }
-        let stat = unsafe { stat.assume_init() };
-        let kind = stat.st_mode & libc::S_IFMT;
-        if kind != libc::S_IFDIR && kind != libc::S_IFREG {
+        if !matches!(
+            FileType::from_raw_mode(stat.st_mode),
+            FileType::Directory | FileType::RegularFile
+        ) {
             return Err(io::Error::new(
                 io::ErrorKind::PermissionDenied,
                 "target is a symlink or special file",
@@ -287,68 +245,38 @@ impl Directory {
         Ok(names)
     }
     pub fn mkdir(&self, name: &str, private: bool) -> io::Result<Self> {
-        let cname = c(name)?;
-        if unsafe {
-            libc::mkdirat(
-                self.0.as_raw_fd(),
-                cname.as_ptr(),
-                if private { 0o700 } else { 0o755 },
-            )
-        } < 0
-        {
-            return Err(io::Error::last_os_error());
-        }
+        fs::mkdirat(
+            &self.0,
+            name,
+            Mode::from_raw_mode(if private { 0o700 } else { 0o755 }),
+        )?;
         self.child(name)
     }
     pub fn create(&self, path: &str) -> io::Result<File> {
         let (dir, name) = self.parent(path)?;
-        let name = c(&name)?;
-        owned(unsafe {
-            libc::openat(
-                dir.0.as_raw_fd(),
-                name.as_ptr(),
-                libc::O_RDWR | libc::O_CREAT | libc::O_EXCL | libc::O_NOFOLLOW | libc::O_CLOEXEC,
-                0o600,
-            )
-        })
+        Ok(fs::openat(
+            &dir.0,
+            &name,
+            OFlags::RDWR | OFlags::CREATE | OFlags::EXCL | OFlags::NOFOLLOW | OFlags::CLOEXEC,
+            Mode::RUSR | Mode::WUSR,
+        )?
+        .into())
     }
     pub fn publish(&self, stage: &Self, target: &str, replace: bool) -> io::Result<bool> {
-        let old = c("tree")?;
-        let new = c(target)?;
+        // Rustix handles flagged renames on both Linux libc variants and macOS.
         let rename = |exchange: bool| {
-            #[cfg(target_os = "linux")]
-            let result = unsafe {
-                libc::renameat2(
-                    stage.0.as_raw_fd(),
-                    old.as_ptr(),
-                    self.0.as_raw_fd(),
-                    new.as_ptr(),
-                    if exchange {
-                        libc::RENAME_EXCHANGE
-                    } else {
-                        libc::RENAME_NOREPLACE
-                    },
-                )
-            };
-            #[cfg(target_os = "macos")]
-            let result = unsafe {
-                libc::renameatx_np(
-                    stage.0.as_raw_fd(),
-                    old.as_ptr(),
-                    self.0.as_raw_fd(),
-                    new.as_ptr(),
-                    if exchange {
-                        libc::RENAME_SWAP
-                    } else {
-                        libc::RENAME_EXCL
-                    },
-                )
-            };
-            if result < 0 {
-                Err(io::Error::last_os_error())
-            } else {
-                Ok(())
-            }
+            fs::renameat_with(
+                &stage.0,
+                "tree",
+                &self.0,
+                target,
+                if exchange {
+                    fs::RenameFlags::EXCHANGE
+                } else {
+                    fs::RenameFlags::NOREPLACE
+                },
+            )
+            .map_err(io::Error::from)
         };
         match rename(false) {
             Ok(()) => Ok(false),
@@ -366,16 +294,12 @@ impl Directory {
             entries: Entries,
         }
         let name = c(name)?;
-        let unlink = |parent: &Directory, name: &CStr, flags: i32| -> io::Result<()> {
-            if unsafe { libc::unlinkat(parent.0.as_raw_fd(), name.as_ptr(), flags) } < 0 {
-                Err(io::Error::last_os_error())
-            } else {
-                Ok(())
-            }
+        let unlink = |parent: &Directory, name: &CStr, flags: AtFlags| -> io::Result<()> {
+            Ok(fs::unlinkat(&parent.0, name, flags)?)
         };
         let directory = match self.child_name(&name) {
             Ok(dir) => dir,
-            Err(_) => return unlink(self, &name, 0),
+            Err(_) => return unlink(self, &name, AtFlags::empty()),
         };
         let mut stack = vec![Frame {
             name,
@@ -399,14 +323,126 @@ impl Directory {
                             directory,
                         });
                     }
-                    Err(_) => unlink(&frame.directory, &name, 0)?,
+                    Err(_) => unlink(&frame.directory, &name, AtFlags::empty())?,
                 }
             } else {
                 let frame = stack.pop().unwrap();
                 let parent = stack.last().map_or(self, |frame| &frame.directory);
-                unlink(parent, &frame.name, libc::AT_REMOVEDIR)?;
+                unlink(parent, &frame.name, AtFlags::REMOVEDIR)?;
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn directory_enumerations_have_independent_offsets_and_enforce_limits() {
+        let root = tempfile::tempdir().unwrap();
+        for name in ["a", "b", "c"] {
+            std::fs::write(root.path().join(name), name).unwrap();
+        }
+        let dir = Directory::anchor(root.path()).unwrap();
+        let mut first = entries(&dir.0).unwrap();
+        let mut observed = vec![first.next().unwrap().unwrap().into_string().unwrap()];
+        assert_eq!(Directory::names(&dir.0, 3).unwrap(), ["a", "b", "c"]);
+        observed.extend(first.map(|name| name.unwrap().into_string().unwrap()));
+        observed.sort();
+        assert_eq!(observed, ["a", "b", "c"]);
+        assert_eq!(
+            Directory::names(&dir.0, 2).unwrap_err().kind(),
+            io::ErrorKind::InvalidInput
+        );
+        assert_eq!(Directory::names(&dir.0, 3).unwrap(), ["a", "b", "c"]);
+    }
+
+    #[test]
+    fn cleanup_removes_nested_trees_without_following_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(outside.path().join("keep"), "untouched").unwrap();
+        let dir = Directory::anchor(root.path()).unwrap();
+        let retired = dir.mkdir("retired", true).unwrap();
+        retired.mkdir("nested", true).unwrap();
+        std::fs::write(root.path().join("retired/nested/file"), "content").unwrap();
+        symlink(outside.path(), root.path().join("retired/link")).unwrap();
+        symlink("missing", root.path().join("retired/dangling")).unwrap();
+        dir.remove_tree("retired").unwrap();
+        assert!(!root.path().join("retired").exists());
+        assert_eq!(
+            std::fs::read_to_string(outside.path().join("keep")).unwrap(),
+            "untouched"
+        );
+    }
+
+    // macOS filesystems reject invalid UTF-8 at creation time.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn cleanup_handles_non_utf8_names() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let root = tempfile::tempdir().unwrap();
+        let dir = Directory::anchor(root.path()).unwrap();
+        dir.mkdir("retired", true).unwrap();
+        let raw_path = root
+            .path()
+            .join("retired")
+            .join(std::ffi::OsStr::from_bytes(b"raw-\xff"));
+        std::fs::create_dir(&raw_path).unwrap();
+        std::fs::write(
+            raw_path.join(std::ffi::OsStr::from_bytes(b"file-\xfe")),
+            "data",
+        )
+        .unwrap();
+        dir.remove_tree("retired").unwrap();
+        assert!(!root.path().join("retired").exists());
+    }
+
+    #[test]
+    fn publication_refuses_overwrite_and_exchanges_replaced_files_and_trees() {
+        for directory in [false, true] {
+            let root = tempfile::tempdir().unwrap();
+            let parent = Directory::anchor(root.path()).unwrap();
+            let stage = parent.mkdir("stage", true).unwrap();
+            let staged = root.path().join("stage/tree");
+            let target = root.path().join("target");
+            let write = |path: &Path, bytes: &[u8]| {
+                if directory {
+                    std::fs::create_dir(path).unwrap();
+                    std::fs::write(path.join("content"), bytes).unwrap();
+                } else {
+                    std::fs::write(path, bytes).unwrap();
+                }
+            };
+            let read = |path: &Path| {
+                std::fs::read(if directory {
+                    path.join("content")
+                } else {
+                    path.to_owned()
+                })
+                .unwrap()
+            };
+
+            write(&staged, b"original");
+            assert!(!parent.publish(&stage, "target", false).unwrap());
+            assert_eq!(read(&target), b"original");
+            assert!(!staged.exists());
+
+            write(&staged, b"replacement");
+            let error = parent.publish(&stage, "target", false).unwrap_err();
+            assert_eq!(error.kind(), io::ErrorKind::AlreadyExists);
+            assert_eq!(read(&target), b"original");
+            assert_eq!(read(&staged), b"replacement");
+
+            assert!(parent.publish(&stage, "target", true).unwrap());
+            assert_eq!(read(&target), b"replacement");
+            // Exchange retains the old target in staging for later cleanup.
+            assert_eq!(read(&staged), b"original");
+        }
     }
 }

--- a/crates/environment-daemon/src/jobs.rs
+++ b/crates/environment-daemon/src/jobs.rs
@@ -1736,7 +1736,11 @@ mod tests {
     async fn wait_for_process_gone(pid: i32) {
         let deadline = std::time::Instant::now() + Duration::from_secs(5);
         loop {
-            if unsafe { libc::kill(pid, 0) } != 0 {
+            if rustix::process::test_kill_process(
+                rustix::process::Pid::from_raw(pid).expect("valid child pid"),
+            )
+            .is_err()
+            {
                 return;
             }
             assert!(
@@ -1822,9 +1826,10 @@ mod tests {
         // The escapee is outside the job's process group; clean it up so it
         // does not outlive the test.
         let pid = read_pid_file(&root.join("escapee.pid"));
-        unsafe {
-            libc::kill(pid, libc::SIGKILL);
-        }
+        let _ = rustix::process::kill_process(
+            rustix::process::Pid::from_raw(pid).expect("valid child pid"),
+            rustix::process::Signal::KILL,
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/environment-daemon/src/process.rs
+++ b/crates/environment-daemon/src/process.rs
@@ -1013,10 +1013,11 @@ fn interrupt_child(child: &mut ProcessChild) {
         ProcessChild::Pty(child) => child.process_id(),
     };
     #[cfg(unix)]
-    if let Some(pid) = pid.and_then(|pid| i32::try_from(pid).ok()) {
-        unsafe {
-            libc::kill(pid, libc::SIGINT);
-        }
+    if let Some(pid) = pid
+        .and_then(|pid| i32::try_from(pid).ok())
+        .and_then(rustix::process::Pid::from_raw)
+    {
+        let _ = rustix::process::kill_process(pid, rustix::process::Signal::INT);
     }
     #[cfg(not(unix))]
     let _ = pid;
@@ -1733,7 +1734,8 @@ mod tests {
 
     #[cfg(unix)]
     fn process_alive(pid: i32) -> bool {
-        unsafe { libc::kill(pid, 0) == 0 }
+        rustix::process::Pid::from_raw(pid)
+            .is_some_and(|pid| rustix::process::test_kill_process(pid).is_ok())
     }
 
     #[cfg(unix)]
@@ -1880,9 +1882,10 @@ mod tests {
             .await;
         assert!(stale.is_err(), "the entry was pruned");
 
-        unsafe {
-            libc::kill(pid, libc::SIGKILL);
-        }
+        let _ = rustix::process::kill_process(
+            rustix::process::Pid::from_raw(pid).expect("valid child pid"),
+            rustix::process::Signal::KILL,
+        );
         wait_for_process_gone(pid).await;
         assert_eq!(manager.leftover_group_count(), 0);
     }
@@ -1926,9 +1929,10 @@ mod tests {
         );
         assert!(process_alive(pid), "the writer was not killed by EPIPE");
 
-        unsafe {
-            libc::kill(pid, libc::SIGKILL);
-        }
+        let _ = rustix::process::kill_process(
+            rustix::process::Pid::from_raw(pid).expect("valid child pid"),
+            rustix::process::Signal::KILL,
+        );
         wait_for_process_gone(pid).await;
     }
 

--- a/crates/environment-daemon/src/process_group.rs
+++ b/crates/environment-daemon/src/process_group.rs
@@ -11,6 +11,9 @@ use std::time::Duration;
 
 use tokio::process::Command;
 
+#[cfg(unix)]
+use rustix::process::{Pid, Signal, kill_process_group, test_kill_process_group};
+
 /// How long a terminated group gets between SIGTERM and SIGKILL.
 #[cfg(not(test))]
 pub(crate) const GROUP_TERM_GRACE: Duration = Duration::from_secs(1);
@@ -33,15 +36,24 @@ pub(crate) fn spawn_in_own_group(command: &mut Command) {
 
 /// True when at least one process is left in the group.
 pub(crate) fn group_alive(pgid: u32) -> bool {
-    signal_group(pgid, 0)
+    #[cfg(unix)]
+    return group_pid(pgid).is_some_and(|pid| test_kill_process_group(pid).is_ok());
+    #[cfg(not(unix))]
+    {
+        let _ = pgid;
+        false
+    }
 }
 
 /// Immediately kills every process left in the group.
 pub(crate) fn kill_group(pgid: u32) -> bool {
     #[cfg(unix)]
-    return signal_group(pgid, libc::SIGKILL);
+    return signal_group(pgid, Signal::KILL);
     #[cfg(not(unix))]
-    return signal_group(pgid, 0);
+    {
+        let _ = pgid;
+        false
+    }
 }
 
 /// Terminates every process left in the group: SIGTERM, a bounded grace
@@ -49,11 +61,11 @@ pub(crate) fn kill_group(pgid: u32) -> bool {
 pub(crate) async fn sweep_group(pgid: u32) -> bool {
     #[cfg(unix)]
     {
-        if !signal_group(pgid, libc::SIGTERM) {
+        if !signal_group(pgid, Signal::TERM) {
             return false;
         }
         tokio::time::sleep(GROUP_TERM_GRACE).await;
-        signal_group(pgid, libc::SIGKILL);
+        signal_group(pgid, Signal::KILL);
         true
     }
     #[cfg(not(unix))]
@@ -64,23 +76,38 @@ pub(crate) async fn sweep_group(pgid: u32) -> bool {
 }
 
 #[cfg(unix)]
-fn signal_group(pgid: u32, signal: i32) -> bool {
-    let Ok(pgid) = i32::try_from(pgid) else {
-        return false;
-    };
-    unsafe { libc::kill(-pgid, signal) == 0 }
+fn group_pid(pgid: u32) -> Option<Pid> {
+    // Group IDs 0 and 1 have special kill semantics rather than naming a child group.
+    let pgid = i32::try_from(pgid).ok().filter(|pid| *pid > 1)?;
+    Pid::from_raw(pgid)
 }
 
-#[cfg(not(unix))]
-fn signal_group(_pgid: u32, _signal: i32) -> bool {
-    false
+#[cfg(unix)]
+fn signal_group(pgid: u32, signal: Signal) -> bool {
+    group_pid(pgid).is_some_and(|pid| kill_process_group(pid, signal).is_ok())
 }
 
 /// Sends `SIGINT` to every process left in the group. Returns true when the
 /// group had at least one member to signal.
 pub(crate) fn interrupt_group(pgid: u32) -> bool {
     #[cfg(unix)]
-    return signal_group(pgid, libc::SIGINT);
+    return signal_group(pgid, Signal::INT);
     #[cfg(not(unix))]
-    return signal_group(pgid, 0);
+    {
+        let _ = pgid;
+        false
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn process_groups_reject_special_and_out_of_range_ids() {
+        for pgid in [0, 1, i32::MAX as u32 + 1, u32::MAX] {
+            assert!(group_pid(pgid).is_none());
+        }
+        assert_eq!(group_pid(42), Pid::from_raw(42));
+    }
 }

--- a/crates/temporal-server/tests/vfs_transfer_live.rs
+++ b/crates/temporal-server/tests/vfs_transfer_live.rs
@@ -286,7 +286,7 @@ async fn run_case(
             "edit"
         });
     } else {
-        features["vfs"]["skills"] = json!({});
+        features["vfs"]["skills"] = json!({"roots": ["/workspace"]});
         features["vfs"]["prompts"] = json!({});
     }
     if mode != "noenv" {

--- a/docs/roadmap/p166-vfs-environment-transfer.md
+++ b/docs/roadmap/p166-vfs-environment-transfer.md
@@ -776,6 +776,20 @@ admission, and rejection of corrupt streams.
 Mixed small/large file regressions verify that every scan and staging read
 fits the remaining step allowance, including a partially consumed read buffer.
 
+Atomic publication uses Rustix's flagged rename API across glibc Linux, musl
+Linux, and macOS, avoiding a direct dependency on libc's `renameat2` symbol,
+which musl does not expose. Regression coverage checks file and directory
+publication, overwrite refusal, and retention of the exchanged target in
+staging for cleanup.
+
+Descriptor-relative opens, metadata checks, creation, removal, and streaming
+directory enumeration also use Rustix, with owned descriptors and no manual
+`DIR` lifetime or errno handling. Enumeration retains independent offsets and
+bounded cleanup, including non-UTF-8 names and symlinks in retired trees. Process
+and process-group signaling use typed Rustix APIs; group IDs with special OS
+semantics are rejected. Direct libc usage is limited to macOS metadata-only
+open flags and native process inspection.
+
 Progress:
 
 - [x] Generic filesystem scan and bounded transfer session contracts.


### PR DESCRIPTION
The envd musl release build failed because atomic publication called `libc::renameat2`, which musl does not expose. Use Rustix's flagged rename API to preserve no-overwrite publication and atomic replacement on Linux and macOS.

Also migrate descriptor-relative filesystem operations, streaming directory enumeration, and process signaling to Rustix. This removes manual unsafe syscall and descriptor/errno handling while preserving independent directory offsets and bounded cleanup. Reject process-group IDs with special OS meanings. Keep direct libc usage only for macOS metadata-only open flags and native process inspection.

Update the live transfer fixture to provide the now-required VFS skill roots, and document the implementation. CI configuration is unchanged.

Validation:
- All 78 native environment-daemon tests passed; scoped Clippy and formatting checks passed.
- The x86_64-unknown-linux-musl release binary builds and runs in the pinned release build image.
- All 4 filesystem backend regression tests passed on musl, including atomic replacement, independent enumeration, symlink-safe cleanup, and non-UTF-8 filenames.
- Both live suites passed sequentially against local services: `vfs_transfer_live` and `environment_registration_live`.
