### PR TITLE
Remove duplicate gateway prompt and skill discovery before runs

### DIFF
--- a/crates/temporal-server/src/gateway/service/mod.rs
+++ b/crates/temporal-server/src/gateway/service/mod.rs
@@ -1050,9 +1050,10 @@ impl GatewayAgentApi {
         let session_id = SessionId::try_new(session_id).map_err(|error| {
             AgentApiError::invalid_request(format!("invalid session id: {error}"))
         })?;
-        let loaded = self
-            .load_session_state_with_current_run_context(&session_id)
-            .await?;
+        // The workflow refreshes prompts and catalogs immediately before idle
+        // run admission. Scanning here too duplicates environment roundtrips
+        // and cannot replace the authoritative refresh at that boundary.
+        let loaded = self.load_session_state(&session_id).await?;
         let notify_on_terminal = run_terminal_notify_intents(
             loaded.state.workflow_tools.lifecycle_controller.as_ref(),
             notify_on_terminal,

--- a/crates/temporal-workflow/src/workflows/session/tests.rs
+++ b/crates/temporal-workflow/src/workflows/session/tests.rs
@@ -1608,6 +1608,14 @@ fn environment_catalog_switch_removal_replays_without_mutating_vfs() {
             environment_id: engine::EnvironmentId::new("first"),
         },
     );
+    // The gateway can submit the first run before any skill catalog exists.
+    assert!(state.context.entries.is_empty());
+    assert!(
+        admissions::should_refresh_runtime_projection_before_admitting(
+            &state,
+            &request_input_run("without-gateway-discovery"),
+        )
+    );
     let vfs_key = ContextEntryKey::new("runtime.catalog.skills.vfs");
     let env_key = ContextEntryKey::new("runtime.catalog.skills.environment");
     for (key, origin) in [
@@ -1677,6 +1685,8 @@ fn environment_catalog_switch_removal_replays_without_mutating_vfs() {
     disabled.lifecycle.config.as_mut().unwrap().features.vfs = None;
     assert!(drive::invalid_environment_catalog_command(&disabled).is_none());
 
+    // A run submitted without gateway discovery must refresh even when the
+    // previously published catalog is still valid: its source may have changed.
     assert!(drive::invalid_environment_catalog_command(&state).is_none());
     assert!(
         admissions::should_refresh_runtime_projection_before_admitting(
@@ -1754,6 +1764,14 @@ fn environment_prompt_switch_removal_replays_without_mutating_vfs() {
         CoreAgentCommand::SetActiveEnvironment {
             environment_id: engine::EnvironmentId::new("first"),
         },
+    );
+    // Prompt discovery also runs when the gateway has not published instructions.
+    assert!(state.context.entries.is_empty());
+    assert!(
+        admissions::should_refresh_runtime_projection_before_admitting(
+            &state,
+            &request_input_run("without-gateway-discovery"),
+        )
     );
     let vfs_key = ContextEntryKey::new("instructions.100.prompts.test");
     let env_key = ContextEntryKey::new("instructions.110.environment");

--- a/docs/documentation/how-it-works/context-and-storage.md
+++ b/docs/documentation/how-it-works/context-and-storage.md
@@ -82,11 +82,13 @@ for the resolution rules.
 
 ## Assemble a turn from recorded inputs
 
-Before an idle session admits new run work, the runtime can refresh the
-material derived from its linked workspaces. That includes prompt sources,
-the VFS skill catalog, and the sub-agent menu. This refresh occurs when no run
-is active or already queued; it is not an unconditional refresh before each
-previously queued task.
+Before an idle session admits new run work, the session workflow refreshes
+material derived from its linked workspaces and selected environment. That
+includes enabled prompt sources, skill catalogs, and the sub-agent menu. The
+gateway submits the run without first repeating this discovery. Session setup,
+configuration changes, and explicit skill reads retain their own refresh paths.
+The admission refresh occurs when no run is active or already queued; it is not
+an unconditional refresh before each previously queued task.
 
 Prompt discovery reads conventional locations such as `.lightspeed/prompts`
 and `.agents/prompts` in linked VFS workspaces. It assembles direct `.md` and
@@ -100,8 +102,9 @@ Selecting a skill submits ordinary run input or steering that asks the model
 to read its document. Skill reads and inserted skill text use ordinary
 conversation retention and compaction. The current catalog remains retained,
 but skill bodies have no dedicated scope, expiry, or protected context state.
-Environment files do not participate in this automatic prompt and skill
-discovery.
+When environment prompt or skill discovery is enabled, the runtime also reads
+its configured sources from the selected environment. Environment and VFS
+sources retain separate ownership.
 
 Once the refreshed inputs are admitted, the turn freezes the context revision
 it uses. Instructions are ordered first by key; other entries follow their


### PR DESCRIPTION
Starting a run on an idle session refreshed prompts and catalogs in the gateway and then repeated discovery in the workflow before admission. With environment sources enabled, both passes opened remote connections and scanned sources, delaying message acceptance.

Load session state without discovery in the gateway run-start path. The workflow remains responsible for refreshing context before idle run admission. Preserve MCP tool-policy reconciliation and refreshes for session setup, configuration changes, and explicit skill reads.

Extend the existing workflow boundary regressions to cover prompt and skill discovery before any entries have been published, and document where admission refresh happens.

Validation: temporal-server and temporal-workflow library tests; `cargo fmt --all --check`; `git diff --check`. Live infrastructure tests were not run.
